### PR TITLE
Adds support for FormatOptions class for controlling outputting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-  id 'idea'
-  id 'java'
-  id 'maven'
-  id 'maven-publish'
-  id 'org.ajoberstar.grgit' version '2.0.1'
+    id 'idea'
+    id 'java'
+    id 'maven'
+    id 'maven-publish'
+    id 'org.ajoberstar.grgit' version '2.0.1'
 }
 
 import org.ajoberstar.grgit.Grgit
@@ -17,118 +17,129 @@ group = 'org.apache.wink.json4j'
 project.version = getVersionCode()
 
 configurations {
-  all {
-    resolutionStrategy {
-      // Uncomment to see if there are dependency issues
-      // failOnVersionConflict()
+    all {
+        resolutionStrategy {
+            // Uncomment to see if there are dependency issues
+            // failOnVersionConflict()
 
-      // Any dependencies with .+ or  build.latest will always be checked for latest
-      cacheDynamicVersionsFor 0, 'seconds'
+            // Any dependencies with .+ or  build.latest will always be checked for latest
+            cacheDynamicVersionsFor 0, 'seconds'
+        }
     }
-  }
 }
 
 repositories {
-  mavenLocal()
-  mavenCentral()
-  jcenter()
+    mavenLocal()
+    mavenCentral()
+    jcenter()
 }
 
 dependencies {
 
-  testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.12'
 
 }
 
 compileJava {
-  options.encoding = 'UTF-8'
-  options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '4.2'
+    gradleVersion = '4.2'
 }
 
 sourceSets {
-  main {
-    java {
-      srcDirs = ['src/main/java']
+    main {
+        java {
+            srcDirs = ['src/main/java']
+        }
     }
-  }
-  test {
-    java {
-      srcDirs = ['src/test/java']
+    test {
+        java {
+            srcDirs = ['src/test/java']
+        }
     }
-  }
 }
 
 ext {
-  startTime = new Date().format("yyy-MM-dd'T'HH:mm:ssZ")
-  applicationTitle = 'Apache Wink :: JSON4J'
-  implementationVendor = 'Elyxor, Inc.'
-  specVendor = 'The Apache Software Foundation'
+    startTime = new Date().format("yyy-MM-dd'T'HH:mm:ssZ")
+    applicationTitle = 'Apache Wink :: JSON4J'
+    implementationVendor = 'Elyxor, Inc.'
+    specVendor = 'The Apache Software Foundation'
 
-  // init local mavenUser/pwd
+    // init local mavenUser/pwd
 
-  def gitRepo = Grgit.open(dir: '.')
-  gitHash = gitRepo.head().id
-  gitBranch = gitRepo.branch.current.name
-  gitRepo.close()
+    def gitRepo = Grgit.open(dir: '.')
+    gitHash = gitRepo.head().id
+    gitBranch = gitRepo.branch.current.name
+    gitRepo.close()
 
-  currentJvm = org.gradle.internal.jvm.Jvm.current()
+    currentJvm = org.gradle.internal.jvm.Jvm.current()
 }
 
 jar {
-  baseName = project.name
-  manifest {
-    attributes(
-      "Manifest-Version": "1.0",
-      "Vendor": project.implementationVendor,
-      "Created-By": project.currentJvm,
-      "Implementation-Title": project.applicationTitle,
-      "Implementation-Version": project.version,
-      "Implementation-Vendor": project.implementationVendor,
-      "Specification-Title": project.applicationTitle,
-      "Specification-Version": project.version,
-      "specification-Vendor": project.specVendor,
-      "Build-Hash": project.gitHash,
-      "Build-Branch":  project.gitBranch,
-      "Build-Time": project.startTime,
-      "Class-Path": configurations.runtime.collect { it.getName() }.join(' ')
-    )
-  }
+    baseName = project.name
+    manifest {
+        attributes(
+                "Manifest-Version": "1.0",
+                "Vendor": project.implementationVendor,
+                "Created-By": project.currentJvm,
+                "Implementation-Title": project.applicationTitle,
+                "Implementation-Version": project.version,
+                "Implementation-Vendor": project.implementationVendor,
+                "Specification-Title": project.applicationTitle,
+                "Specification-Version": project.version,
+                "specification-Vendor": project.specVendor,
+                "Build-Hash": project.gitHash,
+                "Build-Branch": project.gitBranch,
+                "Build-Time": project.startTime,
+                "Class-Path": configurations.runtime.collect { it.getName() }.join(' ')
+        )
+    }
 }
 
 task sourceJar(type: Jar, dependsOn: classes) {
-  classifier = 'sources'
-  baseName = project.name
-  from sourceSets.main.allSource
+    classifier = 'sources'
+    baseName = project.name
+    from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
-  baseName = project.name
-  from javadoc.destinationDir
+    classifier = 'javadoc'
+    baseName = project.name
+    from javadoc.destinationDir
 }
 
-task testjar(type: Jar) {
-  classifier = 'tests'
-  baseName = project.name
-  from sourceSets.test.output
+task testsJar(type: Jar, dependsOn: classes ) {
+    classifier = 'tests'
+    baseName = project.name
+    from sourceSets.test.output
 }
 
+publishing {
+    publications {
+        build(MavenPublication) {
+            version project.version
+            artifact sourceJar
+            artifact javadocJar
+            artifact jar
+            artifact testsJar
+        }
+    }
+}
 test {
-  doFirst {
-    println('RunningTests on ' + maxParallelForks + ' Cores')
-  }
+    doFirst {
+        println('RunningTests on ' + maxParallelForks + ' Cores')
+    }
 
-  maxParallelForks Runtime.runtime.availableProcessors()
+    maxParallelForks Runtime.runtime.availableProcessors()
 
-  jvmArgs '-da', '-Xmx4g'
+    jvmArgs '-da', '-Xmx4g'
 
-  include 'org/apache/wink/**/*Test.class'
+    include 'org/apache/wink/**/*Test*.class'
 
-  testLogging  {
-    events 'passed', 'skipped', 'failed'
-  }
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -105,12 +105,11 @@ task sourceJar(type: Jar, dependsOn: classes) {
   from sourceSets.main.allSource
 }
 
-// Commented out because javadoc doesn't compile
-//task javadocJar(type: Jar, dependsOn: javadoc) {
-//  classifier = 'javadoc'
-//  baseName = project.name
-//  from javadoc.destinationDir
-//}
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  baseName = project.name
+  from javadoc.destinationDir
+}
 
 task testjar(type: Jar) {
   classifier = 'tests'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
+    id 'signing'
     id 'org.ajoberstar.grgit' version '2.0.1'
 }
 
@@ -13,7 +14,7 @@ apply from: 'versioning.gradle'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-group = 'org.apache.wink.json4j'
+group = applicationGroupId
 project.version = getVersionCode()
 
 configurations {
@@ -64,9 +65,6 @@ sourceSets {
 
 ext {
     startTime = new Date().format("yyy-MM-dd'T'HH:mm:ssZ")
-    applicationTitle = 'Apache Wink :: JSON4J'
-    implementationVendor = 'Elyxor, Inc.'
-    specVendor = 'The Apache Software Foundation'
 
     // init local mavenUser/pwd
 
@@ -119,12 +117,32 @@ task testsJar(type: Jar, dependsOn: classes ) {
 
 publishing {
     publications {
-        build(MavenPublication) {
+        json4j(MavenPublication) {
             version project.version
-            artifact sourceJar
-            artifact javadocJar
             artifact jar
-            artifact testsJar
+            artifact sourceJar { classifier 'sources' }
+            artifact javadocJar { classifier 'javadoc' }
+            artifact testsJar { classifier 'tests' }
+            pom.withXml {
+                asNode().children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+                    name project.applicationTitle
+                    description project.applicationDescription
+                    url project.url
+                    scm {
+                        url project.url
+                        connection project.scmUrl
+                        developerConnection project.scmUrl
+                    }
+                    licenses {
+                        license {
+                            name project.licenseName
+                            url project.licenseUrl
+                            distribution 'repo'
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,15 @@
+org.gradle.jvmargs=-Xmx4096m
+
 artifactMajorVersion = 1
 artifactMinorVersion = 5
-org.gradle.jvmargs=-Xmx4096m
+
+applicationGroupId = org.apache.wink
+applicationTitle = Apache Wink :: JSON4J
+applicationDescription = A JSON Parsing library that supports ordered attributes\nIt also handles xml to json, and json to xml conversions\nSee project url for details
+implementationVendor = Elyxor, Inc.
+specVendor = The Apache Software Foundation
+licenseName = The Apache Software License, Version 2.0
+licenseUrl = https://github.com/ElyxorCorp/wink-json4j/blob/master/LICENSE
+url = https://github.com/ElyxorCorp/wink-json4j
+scmUrl = scm:git:https://github.com/ElyxorCorp/wink-json4j.git
+

--- a/src/main/java/org/apache/wink/json4j/JSON.java
+++ b/src/main/java/org/apache/wink/json4j/JSON.java
@@ -19,20 +19,13 @@
 
 package org.apache.wink.json4j;
 
-import java.io.BufferedReader;
-import java.io.CharArrayReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PushbackReader;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 /**
- * Helper class that does generic parsing of a JSON stream and returns the appropriate 
- * JSON structure (JSONArray or JSONObject).  Note that it is slightly more efficient to directly 
- * parse with the appropriate object than to use this class to do a generalized parse.  
+ * Helper class that does generic parsing of a JSON stream and returns the appropriate
+ * JSON structure (JSONArray or JSONObject).  Note that it is slightly more efficient to directly
+ * parse with the appropriate object than to use this class to do a generalized parse.
  */
 public class JSON {
 
@@ -42,96 +35,93 @@ public class JSON {
      */
     public static final Object NULL = null;
 
+    private JSON() {}
 
     /**
-     * Parse a Reader of JSON text into a JSONArtifact. 
+     * Parse a Reader of JSON text into a JSONArtifact.
+     *
      * @param reader The character reader to read the JSON data from.
-     * @param order Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
-     * Note:  The provided reader is not closed on completion of read; that is left to the caller.
-     * Note:  This is the same as calling parse(reader, order, false);
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @param order  Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
+     *               Note:  The provided reader is not closed on completion of read; that is left to the caller.
+     *               Note:  This is the same as calling parse(reader, order, false);
+     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if reader is null
      */
-    public static JSONArtifact parse(Reader reader, boolean order) throws JSONException, NullPointerException {
-        return parse(reader,order,false);
+    public static JSONArtifact parse(Reader reader, boolean order) throws JSONException {
+        return parse(reader, order, false);
     }
+
     /**
-     * Parse a Reader of JSON text into a JSONArtifact. 
+     * Parse a Reader of JSON text into a JSONArtifact.
+     *
      * @param reader The character reader to read the JSON data from.
-     * @param order Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
+     * @param order  Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
      * @param strict Boolean flag to indicate if the content should be parsed in strict mode or not, meaning comments and unquoted strings are not allowed.
-     * Note:  The provided reader is not closed on completion of read; that is left to the caller.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     *               Note:  The provided reader is not closed on completion of read; that is left to the caller.
+     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if reader is null
      */
-    public static JSONArtifact parse(Reader reader, boolean order, boolean strict) throws JSONException, NullPointerException {
+    public static JSONArtifact parse(Reader reader, boolean order, boolean strict) throws JSONException {
+
+        if (null == reader) {
+            throw new JSONException("reader cannot be null.");
+        }
 
         try {
-            if (reader != null) {
+            PushbackReader pReader;
 
-                PushbackReader pReader = null;
+            //Determine if we should buffer-wrap the reader before passing it on
+            //to the appropriate parser.
+            boolean bufferIt = false;
 
-                //Determine if we should buffer-wrap the reader before passing it on
-                //to the appropriate parser.
-                boolean bufferIt = false;
+            Class readerClass = reader.getClass();
 
-                Class readerClass = reader.getClass();
-
-                if (!StringReader.class.isAssignableFrom(readerClass) && 
+            if (!StringReader.class.isAssignableFrom(readerClass) &&
                     !CharArrayReader.class.isAssignableFrom(readerClass) &&
                     !PushbackReader.class.isAssignableFrom(readerClass) &&
                     !BufferedReader.class.isAssignableFrom(readerClass)) {
-                    bufferIt = true;
-                }
-
-                if (PushbackReader.class.isAssignableFrom(readerClass)) {
-                    pReader = (PushbackReader) reader;
-                } else {
-                    pReader = new PushbackReader(reader);
-                }
-
-                Reader rdr = pReader;
-                int ch = pReader.read();
-                while (ch != -1) {
-                    switch (ch) {
-                        case '{':
-                            pReader.unread(ch);
-                            if (bufferIt) {
-                                rdr = new BufferedReader(pReader);
-                            }
-                            if (order) {
-                                return new OrderedJSONObject(rdr, strict);
-                            } else {
-                                return new JSONObject(rdr,strict);
-                            }
-                        case '[':
-                            pReader.unread(ch);
-                            if (bufferIt) {
-                                rdr = new BufferedReader(pReader);
-                            }
-                            return new JSONArray(rdr, strict);
-                        case ' ':
-                        case '\t':
-                        case '\f':
-                        case '\r':
-                        case '\n':
-                        case '\b':
-                            ch = pReader.read();
-                            break;
-                        default:
-                            throw new JSONException("Unexpected character: [" + (char)ch + "] while scanning JSON String for JSON type.  Invalid JSON."); 
-                    }
-                }
-                throw new JSONException("Encountered end of stream before JSON data was read.  Invalid JSON");
-            } else {
-                throw new NullPointerException("reader cannot be null.");
+                bufferIt = true;
             }
+
+            if (PushbackReader.class.isAssignableFrom(readerClass)) {
+                pReader = (PushbackReader) reader;
+            } else {
+                pReader = new PushbackReader(reader);
+            }
+
+            Reader rdr = pReader;
+            int ch = pReader.read();
+            while (ch != -1) {
+                switch (ch) {
+                    case '{':
+                        pReader.unread(ch);
+                        if (bufferIt) {
+                            rdr = new BufferedReader(pReader);
+                        }
+                        if (order) {
+                            return new OrderedJSONObject(rdr, strict);
+                        } else {
+                            return new JSONObject(rdr, strict);
+                        }
+                    case '[':
+                        pReader.unread(ch);
+                        if (bufferIt) {
+                            rdr = new BufferedReader(pReader);
+                        }
+                        return new JSONArray(rdr, strict);
+                    case ' ':
+                    case '\t':
+                    case '\f':
+                    case '\r':
+                    case '\n':
+                    case '\b':
+                        ch = pReader.read();
+                        break;
+                    default:
+                        throw new JSONException("Unexpected character: [" + (char) ch + "] while scanning JSON String for JSON type.  Invalid JSON.");
+                }
+            }
+            throw new JSONException("Encountered end of stream before JSON data was read.  Invalid JSON");
         } catch (IOException iox) {
             JSONException jex = new JSONException("Error occurred during input read.");
             jex.initCause(iox);
@@ -140,123 +130,105 @@ public class JSON {
     }
 
     /**
-     * Parse a Reader of JSON text into a JSONArtifact.  
+     * Parse a Reader of JSON text into a JSONArtifact.
      * This call is the same as JSON.parse(reader, false, false).
      * Note that the provided reader is not closed on completion of read; that is left to the caller.
+     *
      * @param reader The character reader to read the JSON data from.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if reader is null
      */
-    public static JSONArtifact parse(Reader reader) throws JSONException, NullPointerException {
-        return parse(reader,false, false);
+    public static JSONArtifact parse(Reader reader) throws JSONException {
+        return parse(reader, false, false);
     }
 
 
     /**
-     * Parse a InputStream of JSON text into a JSONArtifact. 
+     * Parse a InputStream of JSON text into a JSONArtifact.
      * Note:  The provided InputStream is not closed on completion of read; that is left to the caller.
-     * @param is The input stream to read from.  The content is assumed to be UTF-8 encoded and handled as such.
+     *
+     * @param is    The input stream to read from.  The content is assumed to be UTF-8 encoded and handled as such.
      * @param order Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if reader is null
      */
-    public static JSONArtifact parse(InputStream is, boolean order) throws JSONException, NullPointerException {
-        return parse(is,order, false);
+    public static JSONArtifact parse(InputStream is, boolean order) throws JSONException {
+        return parse(is, order, false);
     }
+
     /**
-     * Parse a InputStream of JSON text into a JSONArtifact. 
-     * Note that the provided InputStream is not closed on completion of read; that is left to the caller.
-     * @param is The input stream to read from.  The content is assumed to be UTF-8 encoded and handled as such.
-     * @param order Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
+     * Parse a InputStream of JSON text into a JSONArtifact.
+     *
+     * @param is     The input stream to read from.  The content is assumed to be UTF-8 encoded and handled as such.
+     * @param order  Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
      * @param strict Boolean flag to indicate if the content should be parsed in strict mode or not, meaning comments and unquoted strings are not allowed.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if reader is null
      */
-    public static JSONArtifact parse(InputStream is, boolean order, boolean strict) throws JSONException, NullPointerException {
-        if (is != null) {
-            BufferedReader reader = null;
-            try {
-                reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-            } catch (Exception ex) {
-                JSONException iox = new JSONException("Could not construct UTF-8 character reader for the InputStream");
-                iox.initCause(ex);
-                throw iox;
-            }
-            return parse(reader,order);
-        } else {
+    public static JSONArtifact parse(InputStream is, boolean order, boolean strict) throws JSONException {
+
+        if (null == is) {
             throw new NullPointerException("is cannot be null");
         }
 
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            return parse(reader, order);
+        } catch (Exception ex) {
+            JSONException iox = new JSONException("Could not construct UTF-8 character reader for the InputStream");
+            iox.initCause(ex);
+            throw iox;
+        }
     }
 
     /**
      * Parse an InputStream of JSON text into a JSONArtifact.
      * This call is the same as JSON.parse(is, false, false).
-     * Note that the provided InputStream is not closed on completion of read; that is left to the caller.
+     *
      * @param is The input stream to read from.  The content is assumed to be UTF-8 encoded and handled as such.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if reader is null
      */
-    public static JSONArtifact parse(InputStream is) throws JSONException, NullPointerException {
-        return parse(is,false, false);
+    public static JSONArtifact parse(InputStream is) throws JSONException {
+        return parse(is, false, false);
     }
 
     /**
-     * Parse a string of JSON text into a JSONArtifact. 
-     * @param str The String to read from.  
+     * Parse a string of JSON text into a JSONArtifact.
+     *
+     * @param str   The String to read from.
      * @param order Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if str is null
      */
-    public static JSONArtifact parse(String str, boolean order) throws JSONException, NullPointerException {
-        return parse(str,order,false);
+    public static JSONArtifact parse(String str, boolean order) throws JSONException {
+        return parse(str, order, false);
     }
 
     /**
-     * Parse a string of JSON text into a JSONArtifact. 
-     * @param str The String to read from.  
-     * @param order Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
+     * Parse a string of JSON text into a JSONArtifact.
+     *
+     * @param str    The String to read from.
+     * @param order  Boolean flag indicating if the order of the JSON data should be preserved.  This parameter only has an effect if the stream is JSON Object { ... } formatted data.
      * @param strict Boolean flag to indicate if the content should be parsed in strict mode or not, meaning comments and unquoted strings are not allowed.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
+     * @return Returns an instance of JSONArtifact (JSONObject or JSONArray), corresponding to if the input stream was Object or Array notation.
      * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if str is null
      */
-    public static JSONArtifact parse(String str, boolean order, boolean strict) throws JSONException, NullPointerException {
-        if (str != null) {
-            return parse(new StringReader(str), order, strict);
-        } else {
-            throw new NullPointerException("str cannot be null");
+    public static JSONArtifact parse(String str, boolean order, boolean strict) throws JSONException {
+        if (null == str) {
+            throw new JSONException("str cannot be null");
         }
+        return parse(new StringReader(str), order, strict);
     }
 
     /**
-     * Parse a string of JSON text into a JSONArtifact. 
+     * Parse a string of JSON text into a JSONArtifact.
      * This call is the same as JSON.parse(str, false, false).
+     *
      * @param str The String to read from.
-     *
-     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corrisponding to if the input stream was Object or Array notation.
-     *
-     * @throws JSONException Thrown on errors during parse.
-     * @throws NullPointerException Thrown if str is null
+     * @return Returns an instance of JSONArtifact (JSONObject, OrderedJSONObject, or JSONArray), corresponding to if the input stream was Object or Array notation.
+     * @throws JSONException        Thrown on errors during parse.
      */
-    public static JSONArtifact parse(String str) throws JSONException, NullPointerException {
+    public static JSONArtifact parse(String str) throws JSONException {
         return parse(str, false, false);
     }
 }

--- a/src/main/java/org/apache/wink/json4j/JSON.java
+++ b/src/main/java/org/apache/wink/json4j/JSON.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Helper class that does generic parsing of a JSON stream and returns the appropriate 
@@ -184,7 +185,7 @@ public class JSON {
         if (is != null) {
             BufferedReader reader = null;
             try {
-                reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+                reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             } catch (Exception ex) {
                 JSONException iox = new JSONException("Could not construct UTF-8 character reader for the InputStream");
                 iox.initCause(ex);

--- a/src/main/java/org/apache/wink/json4j/JSONArray.java
+++ b/src/main/java/org/apache/wink/json4j/JSONArray.java
@@ -687,18 +687,23 @@ public class JSONArray extends ArrayList implements JSONArtifact {
 
     /**
      * Function to obtain a value at the specified index as a boolean.
-     * This will return <tt>true</tt> if:<p/>
+     * <p>
+     * This will return <tt>true</tt> if:
+     * </p>
      * <ul>
-     * <li>the backing value is a <tt>Boolean</tt> and is <tt>true</tt></li>
-     * <li>the backing value is a <tt>String</tt> and is <tt>"true"</tt></li>
+     *   <li>the backing value is a <tt>Boolean</tt> and is <tt>true</tt></li>
+     *   <li>the backing value is a <tt>String</tt> and is <tt>"true"</tt></li>
      * </ul>
-     * This will return <tt>false</tt> if:<p/>
+     * <p>
+     * This will return <tt>false</tt> if:
+     * </p>
      * <ul>
-     * <li>the backing value is a <tt>Boolean</tt> and is <tt>false</tt></li>
-     * <li>the backing value is a <tt>String</tt> and is <tt>"false"</tt></li>
+     *   <li>the backing value is a <tt>Boolean</tt> and is <tt>false</tt></li>
+     *   <li>the backing value is a <tt>String</tt> and is <tt>"false"</tt></li>
      * </ul>
      * <p>
      * It will throw an exception for any other value
+     * </p>
      *
      * @param index The index of the item to retrieve.
      * @return boolean value - see description

--- a/src/main/java/org/apache/wink/json4j/JSONArray.java
+++ b/src/main/java/org/apache/wink/json4j/JSONArray.java
@@ -965,16 +965,14 @@ public class JSONArray extends ArrayList implements JSONArtifact {
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public OutputStream write(OutputStream os, boolean verbose) throws JSONException {
-        Writer writer = null;
-        try {
-            writer = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-        } catch (UnsupportedEncodingException uex) {
-            JSONException jex = new JSONException(uex.toString());
-            jex.initCause(uex);
+        try (Writer writer = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8))) {
+            write(writer, verbose);
+            return os;
+        } catch (IOException ioe) {
+            JSONException jex = new JSONException(ioe.toString());
+            jex.initCause(ioe);
             throw jex;
         }
-        write(writer, verbose);
-        return os;
     }
 
     /**
@@ -986,16 +984,14 @@ public class JSONArray extends ArrayList implements JSONArtifact {
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public OutputStream write(OutputStream os, int indentDepth) throws JSONException {
-        Writer writer = null;
-        try {
-            writer = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-        } catch (UnsupportedEncodingException uex) {
-            JSONException jex = new JSONException(uex.toString());
-            jex.initCause(uex);
+        try (Writer writer = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8))) {
+            write(writer, indentDepth);
+            return os;
+        } catch (IOException ioe) {
+            JSONException jex = new JSONException(ioe.toString());
+            jex.initCause(ioe);
             throw jex;
         }
-        write(writer, indentDepth);
-        return os;
     }
 
     /**

--- a/src/main/java/org/apache/wink/json4j/JSONArtifact.java
+++ b/src/main/java/org/apache/wink/json4j/JSONArtifact.java
@@ -19,6 +19,8 @@
 
 package org.apache.wink.json4j;
 
+import org.apache.wink.json4j.formatter.FormatOptions;
+
 import java.io.OutputStream;
 import java.io.Writer;
 
@@ -27,94 +29,103 @@ import java.io.Writer;
  * This is namely so that functions such as write, which are common between the two, can be easily
  * invoked without knowing the object type.
  */
-public interface JSONArtifact
-{
+public interface JSONArtifact {
     /**
      * Write this object to the stream as JSON text in UTF-8 encoding.  Same as calling write(os,false);
      * Note that encoding is always written as UTF-8, as per JSON spec.
+     *
      * @param os The output stream to write data to.
      * @return The passed in OutputStream.
-     *
      * @throws JSONException Thrown on errors during serialization.
      */
-    public OutputStream write(OutputStream os) throws JSONException;
+    OutputStream write(OutputStream os) throws JSONException;
 
     /**
      * Write this object to the stream as JSON text in UTF-8 encoding, specifying whether to use verbose (tab-indented) output or not.
      * Note that encoding is always written as UTF-8, as per JSON spec.
-     * @param os The output stream to write data to.
+     *
+     * @param os      The output stream to write data to.
      * @param verbose Whether or not to write the JSON text in a verbose format.  If true, will indent via tab.
      * @return The passed in OutputStream.
-     *
      * @throws JSONException Thrown on errors during serialization.
      */
-    public OutputStream write(OutputStream os, boolean verbose) throws JSONException;
+    OutputStream write(OutputStream os, boolean verbose) throws JSONException;
 
     /**
-     * Write this object to the stream as JSON text in UTF-8 encoding, specifying how many spaces should be used for each indent.  
+     * Write this object to the stream as JSON text in UTF-8 encoding, specifying how many spaces should be used for each indent.
      * This is an alternate indent style to using tabs.
-     * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.
-     * Less than one means no indenting, greater than 8 and it will just use tab.
-     * @return The passed in OutputStream.
      *
+     * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.
+     *                    Less than one means no indenting, greater than 8 and it will just use tab.
+     * @return The passed in OutputStream.
      * @throws JSONException Thrown on errors during serialization.
      */
-    public OutputStream write(OutputStream os, int indentDepth) throws JSONException;
+    OutputStream write(OutputStream os, int indentDepth) throws JSONException;
 
     /**
      * Write this object to the writer as JSON text.  Same as calling write(writer,false);
+     *
      * @param writer The writer which to write the JSON text to.
      * @return The passed in writer.
-     *
      * @throws JSONException Thrown on errors during serialization.
      */
-    public Writer write(Writer writer) throws JSONException;
-    
+    Writer write(Writer writer) throws JSONException;
+
     /**
      * Writer this object to the writer as JSON text, specifying whether to use verbose (tab-indented) output or not.
      * be used for each indent.  This is an alternate indent style to using tabs.
-     * @param writer The writer which to write the JSON text to.
+     *
+     * @param writer  The writer which to write the JSON text to.
      * @param verbose pass <strong>true</strong> for verbose mode
      * @return The passed in writer.
-     *
      * @throws JSONException Thrown on errors during serialization.
      */
-    public Writer write(Writer writer, boolean verbose) throws JSONException;
-    
+    Writer write(Writer writer, boolean verbose) throws JSONException;
+
     /**
-     * Write this object to the writer as JSON text, specifying how many spaces should be used for each indent.  
+     * Write this object to the writer as JSON text, specifying how many spaces should be used for each indent.
      * This is an alternate indent style to using tabs.
-     * @param writer The writer which to write the JSON text to.
+     *
+     * @param writer      The writer which to write the JSON text to.
      * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.
      * @return The passed in writer.
-     *
      * @throws JSONException Thrown on errors during serialization.
      */
-    public Writer write(Writer writer, int indentDepth) throws JSONException;
+    Writer write(Writer writer, int indentDepth) throws JSONException;
 
     /**
      * Convert this object into a String of JSON text, specifying whether to use verbose (tab-indented) output or not.
+     *
      * @param verbose Whether or not to write in compressed format.
-     * Less than one means no indenting, greater than 8 and it will just use tab.
-     *
+     *                Less than one means no indenting, greater than 8 and it will just use tab.
      * @throws JSONException Thrown on errors during serialization.
      */
-    public String write(boolean verbose) throws JSONException;
-    
+    String write(boolean verbose) throws JSONException;
+
     /**
-     * Convert this object into a String of JSON text, specifying how many spaces should be used for each indent.  
+     * Convert this object into a String of JSON text, specifying how many spaces should be used for each indent.
      * This is an alternate indent style to using tabs.
-     * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.  
-     * Less than one means no indenting, greater than 8 and it will just use tab.
      *
+     * @param indentDepth How many spaces to use for each indent.  The value must be greater than 0 or it will
+     *                    throw an <tt>IllegalArgumentException</tt>
      * @throws JSONException Thrown on errors during serialization.
      */
-    public String write(int indentDepth) throws JSONException;
+    String write(int indentDepth) throws JSONException;
+
+    /**
+     * Convert this object into a String of JSON text using the passed object to determine the formatting
+     * options.
+     *
+     * @param formatOptions formatting options
+     * @return a String, if possible
+     * @throws JSONException Thrown on errors during serialization.
+     */
+    String write(FormatOptions formatOptions) throws JSONException;
 
     /**
      * Convert this object into a String of JSON text.  Same as write(false);
      *
      * @throws JSONException Thrown on errors during serialization.
      */
-    public String write() throws JSONException;
+    String write() throws JSONException;
 }

--- a/src/main/java/org/apache/wink/json4j/JSONObject.java
+++ b/src/main/java/org/apache/wink/json4j/JSONObject.java
@@ -30,11 +30,13 @@ import java.util.*;
  * <p>
  * Extension of <tt>HashMap</tt> that only allows <tt>String</tt> keys,
  * and values which are JSON-able (such as a Java Bean).
- * <br/><br/>
+ * </p>
+ * <p>
  * JSON-able values are: <tt>null</tt>, and instances of <tt>String</tt>,
  * <tt>Boolean</tt>, <tt>Number</tt>, <tt>JSONObject</tt> and
  * <tt>JSONArray</tt>.
- * <br/><br/>
+ * </p>
+ * <p>
  * Constructors that fill this object from a string will parse json formatted strings
  * with keys that are unquoted.. e.g.
  * <pre>
@@ -43,19 +45,20 @@ import java.util.*;
  *       other_key: 12345
  *   }
  *   </pre>
- * <br/>
+ * <p>
  * Constructors will also parse objects when there are <tt>C-style</tt> and
  * <tt>CPP-style</tt> comments, however, it does not retain the comments, so saving
  * the JSON after parsing it will lose the comments. For now.
+ * </p>
  * <p>
- * <br/><br/>
  * Instances of this class are not thread-safe.
- * <br/><br/>
+ * </p>
+ * <p>
  * This code does not handle the parsing of <tt>Double</tt> values using
  * <strong>Hexadecimal Floating-point Constants</strong> which are of the format
  * <tt>0x1.0p64</tt>.  For more info on this number representation, please
- * visit <a href="">this page</a>
- * <br/>
+ * visit <a href="http://www.exploringbinary.com/hexadecimal-floating-point-constants/">this page</a>
+ * </p>
  * There is a commented out test for this in <tt>JSONObjectTest::test_opt_ReturnsDoubleClass_whenValueOutOfLongRange()</tt>
  */
 public class JSONObject extends HashMap implements JSONArtifact {
@@ -1549,7 +1552,7 @@ public class JSONObject extends HashMap implements JSONArtifact {
 
     /**
      * Over-ridden toString() method.  Returns the same value as write(), which is a compact JSON String.
-     * If an error occurs in the serialization, the return will be of format: JSON Generation Error: [<some error>]
+     * If an error occurs in the serialization, the return will be of format: JSON Generation Error: [&lt;some error$gt;]
      *
      * @return A string of JSON text, if possible.
      * @see #write()
@@ -1560,7 +1563,7 @@ public class JSONObject extends HashMap implements JSONArtifact {
 
     /**
      * Verbose capable toString method.
-     * If an error occurs in the serialization, the return will be of format: JSON Generation Error: [<some error>]
+     * If an error occurs in the serialization, the return will be of format: JSON Generation Error: [&lt;some error$gt;]
      *
      * @param verbose Whether or not to tab-indent the output.
      * @return A string of JSON text, if possible.

--- a/src/main/java/org/apache/wink/json4j/JSONObject.java
+++ b/src/main/java/org/apache/wink/json4j/JSONObject.java
@@ -19,76 +19,58 @@
 
 package org.apache.wink.json4j;
 
-import java.io.BufferedWriter;
-import java.io.CharArrayWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import org.apache.wink.json4j.formatter.FormatOptions;
+import org.apache.wink.json4j.internal.*;
 
-import org.apache.wink.json4j.internal.BeanSerializer;
-import org.apache.wink.json4j.internal.Null;
-import org.apache.wink.json4j.internal.Parser;
-import org.apache.wink.json4j.internal.Serializer;
-import org.apache.wink.json4j.internal.SerializerVerbose;
+import java.io.*;
+import java.util.*;
 
 /**
  * Models a JSON Object.
- * 
- * Extension of <code>HashMap</code> that only allows <code>String</code> keys,
+ * <p>
+ * Extension of <tt>HashMap</tt> that only allows <tt>String</tt> keys,
  * and values which are JSON-able (such as a Java Bean).
  * <br/><br/>
- * JSON-able values are: <code>null</code>, and instances of <code>String</code>,
- * <code>Boolean</code>, <code>Number</code>, <code>JSONObject</code> and
- * <code>JSONArray</code>.
+ * JSON-able values are: <tt>null</tt>, and instances of <tt>String</tt>,
+ * <tt>Boolean</tt>, <tt>Number</tt>, <tt>JSONObject</tt> and
+ * <tt>JSONArray</tt>.
  * <br/><br/>
  * Constructors that fill this object from a string will parse json formatted strings
- *   with keys that are unquoted.. e.g.
- *   <pre>
+ * with keys that are unquoted.. e.g.
+ * <pre>
  *   {
  *       some_key: "This is a String",
  *       other_key: 12345
  *   }
  *   </pre>
  * <br/>
- * Constructors will also parse objects when there are <code>C-style</code> and
- * <code>CPP-style</code> comments, however, it does not retain the comments, so saving
+ * Constructors will also parse objects when there are <tt>C-style</tt> and
+ * <tt>CPP-style</tt> comments, however, it does not retain the comments, so saving
  * the JSON after parsing it will lose the comments. For now.
- *
+ * <p>
  * <br/><br/>
  * Instances of this class are not thread-safe.
  * <br/><br/>
- * This code does not handle the parsing of <code>Double</code> values using
+ * This code does not handle the parsing of <tt>Double</tt> values using
  * <strong>Hexadecimal Floating-point Constants</strong> which are of the format
- * <code>0x1.0p64</code>.  For more info on this number representation, please
+ * <tt>0x1.0p64</tt>.  For more info on this number representation, please
  * visit <a href="">this page</a>
  * <br/>
- * There is a commented out test for this in <code>JSONObjectTest::test_opt_ReturnsDoubleClass_whenValueOutOfLongRange()</code>
+ * There is a commented out test for this in <tt>JSONObjectTest::test_opt_ReturnsDoubleClass_whenValueOutOfLongRange()</tt>
  */
-public class JSONObject extends HashMap  implements JSONArtifact {
+public class JSONObject extends HashMap implements JSONArtifact {
 
     private static final long serialVersionUID = -3269263069889337298L;
 
     /**
-     * A constant definition reference to Java null.  
+     * A constant definition reference to Java null.
      * Provided for API compatibility with other JSON parsers.
      */
     public static final Object NULL = new Null();
 
     /**
      * Return whether the object is a valid value for a property.
+     *
      * @param object The object to check for validity as a JSON property value.
      * @return boolean indicating if the provided object is directly convertable to JSON.
      */
@@ -99,13 +81,14 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * Return whether the class is a valid type of value for a property.
+     *
      * @param clazz The class type to check for validity as a JSON object type.
      * @return boolean indicating if the provided class is directly convertable to JSON.
      */
     public static boolean isValidType(Class clazz) {
         if (null == clazz) throw new IllegalArgumentException();
 
-        if (String.class  == clazz) return true;
+        if (String.class == clazz) return true;
         if (Boolean.class == clazz) return true;
         if (JSONObject.class.isAssignableFrom(clazz)) return true;
         if (JSONArray.class == clazz) return true;
@@ -116,7 +99,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     }
 
     /**
-     * Create a new instance of this class. 
+     * Create a new instance of this class.
      */
     public JSONObject() {
         super();
@@ -125,11 +108,12 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Create a new instance of this class taking selected values from the underlying one.  If a key is not
      * found, then it will be copied into the new JSONObject.
-     * @param obj The JSONObject to extract values from.
+     *
+     * @param obj  The JSONObject to extract values from.
      * @param keys The keys to take from the JSONObject and apply to this instance.
      * @throws JSONException Thrown if a key is duplicated in the string[] keys
      */
-    public JSONObject(JSONObject obj, String[] keys) throws JSONException{
+    public JSONObject(JSONObject obj, String[] keys) throws JSONException {
         super();
         if (keys != null && keys.length > 0) {
             for (int i = 0; i < keys.length; i++) {
@@ -137,7 +121,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
                     throw new JSONException("Duplicate key: " + keys[i]);
                 }
                 try {
-                	Object item = obj.opt(keys[i]);
+                    Object item = obj.opt(keys[i]);
                     if (item != null) {
                         this.put(keys[i], item);
                     }
@@ -153,32 +137,36 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Create a new instance of this class from the provided JSON object string.
      * Note:  This is the same as new JSONObject(str, false);  Parsing in non-strict mode.
-     * @param str The JSON string to parse.  
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     *
+     * @param str The JSON string to parse.
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
     public JSONObject(String str) throws JSONException {
-        super();
-        StringReader reader = new StringReader(str);
-        (new Parser(reader)).parse(this);
+        this(str, false);
     }
 
     /**
      * Create a new instance of this class from the provided JSON object string.
-     * @param str The JSON string to parse.  
+     *
+     * @param str    The JSON string to parse.
      * @param strict Whether or not to parse in 'strict' mode, meaning all strings must be quoted (including identifiers), and comments are not allowed.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
+    @SuppressWarnings("EmptyFinallyBlock")
     public JSONObject(String str, boolean strict) throws JSONException {
         super();
-        StringReader reader = new StringReader(str);
-        (new Parser(reader, strict)).parse(this);
+        try (StringReader reader = new StringReader(str)) {
+            (new Parser(reader, strict)).parse(this);
+        } finally {
+        }
     }
 
     /**
      * Create a new instance of this class from the data provided from the reader.  The reader content must be a JSON object string.
      * Note:  The reader will not be closed, that is left to the caller.
      * Note:  This is the same as new JSONObject(rdr, false);  Parsing in non-strict mode.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     *
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
     public JSONObject(Reader rdr) throws JSONException {
         (new Parser(rdr)).parse(this);
@@ -187,9 +175,10 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Create a new instance of this class from the data provided from the reader.  The reader content must be a JSON object string.
      * Note:  The reader will not be closed, that is left to the caller.
-     * @param rdr The reader from which to read the JSON.
+     *
+     * @param rdr    The reader from which to read the JSON.
      * @param strict Whether or not to parse in 'strict' mode, meaning all strings must be quoted (including identifiers), and comments are not allowed.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
     public JSONObject(Reader rdr, boolean strict) throws JSONException {
         (new Parser(rdr, strict)).parse(this);
@@ -200,10 +189,11 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Note:  The input stream content is assumed to be UTF-8 encoded.
      * Note:  The InputStream will not be closed, that is left to the caller.
      * Note:  This is the same as new JSONObject(is, false);  Parsing in non-strict mode.
+     *
      * @param is The InputStream from which to read the JSON.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
-    public JSONObject (InputStream is) throws JSONException {
+    public JSONObject(InputStream is) throws JSONException {
         InputStreamReader isr = null;
         if (is != null) {
             try {
@@ -221,11 +211,12 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Create a new instance of this class from the data provided from the input stream.  The stream content must be a JSON object string.
      * Note:  The input stream content is assumed to be UTF-8 encoded.
      * Note:  The InputStream will not be closed, that is left to the caller.
-     * @param is The InputStream from which to read the JSON.
+     *
+     * @param is     The InputStream from which to read the JSON.
      * @param strict Whether or not to parse in 'strict' mode, meaning all strings must be quoted (including identifiers), and comments are not allowed.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
-    public JSONObject (InputStream is, boolean strict) throws JSONException {
+    public JSONObject(InputStream is, boolean strict) throws JSONException {
         InputStreamReader isr = null;
         if (is != null) {
             try {
@@ -240,9 +231,10 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     }
 
     /**
-     * Create a new instance of this class using the contents of the provided map.  
-     * The contents of the map should be values considered JSONable.  
+     * Create a new instance of this class using the contents of the provided map.
+     * The contents of the map should be values considered JSONable.
      * It will try to convert JavaBeans in the map to JSONObjects if possible.
+     *
      * @param map The map of key/value pairs to insert into this JSON object
      */
     public JSONObject(Map map) {
@@ -268,40 +260,43 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Create a new instance of this class using the properties of the provided JavaBean.
      * The bean is converted to a JSONObject via reflection of getter methods.
+     *
      * @param javaBean A java bean with getters for properties.
-     * @throws JSONException Thrown when contents in the map cannot be made JSONable.
+     * @throws JSONException        Thrown when contents in the map cannot be made JSONable.
      * @throws NullPointerException Thrown if the map is null, or a key in the map is null..
      */
     public JSONObject(Object javaBean) throws JSONException {
         super();
         if (javaBean != null) {
-            JSONObject map = (JSONObject)BeanSerializer.toJson(javaBean, true);
+            JSONObject map = (JSONObject) BeanSerializer.toJson(javaBean, true);
             this.putAll(map);
         }
     }
 
     /**
-    * Create a new instance of this class using the properties of the provided JavaBean.
-    * The bean is converted to a JSONObject via reflection of getter methods.
-     * @param javaBean A java bean with getters for properties.
+     * Create a new instance of this class using the properties of the provided JavaBean.
+     * The bean is converted to a JSONObject via reflection of getter methods.
+     *
+     * @param javaBean          A java bean with getters for properties.
      * @param includeSuperclass Boolean indicating that if the object is a JavaBean, include superclass getter properties.
-     * @throws JSONException Thrown when contents in the map cannot be made JSONable.
+     * @throws JSONException        Thrown when contents in the map cannot be made JSONable.
      * @throws NullPointerException Thrown if the map is null, or a key in the map is null..
      */
     public JSONObject(Object javaBean, boolean includeSuperclass) throws JSONException {
         super();
         if (javaBean != null) {
-            JSONObject map = (JSONObject)BeanSerializer.toJson(javaBean, includeSuperclass);
+            JSONObject map = (JSONObject) BeanSerializer.toJson(javaBean, includeSuperclass);
             this.putAll(map);
         }
     }
 
     /**
-     * Create a new instance of this class using the contents of the provided map.  
+     * Create a new instance of this class using the contents of the provided map.
      * The contents of the map should be values considered JSONable.
-     * @param map The map of key/value pairs to insert into this JSON object
+     *
+     * @param map               The map of key/value pairs to insert into this JSON object
      * @param includeSuperclass For values of the map which are JavaBeans, include superclass getter properties.
-     * @throws JSONException Thrown when contents in the map cannot be made JSONable.
+     * @throws JSONException        Thrown when contents in the map cannot be made JSONable.
      * @throws NullPointerException Thrown if the map is null, or a key in the map is null..
      */
     public JSONObject(Map map, boolean includeSuperclass) throws JSONException {
@@ -322,21 +317,21 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Write this object to the stream as JSON text in UTF-8 encoding.  Same as calling write(os,false);
      * Note that encoding is always written as UTF-8, as per JSON spec.
-     * @param os The output stream to write data to.
      *
+     * @param os The output stream to write data to.
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public OutputStream write(OutputStream os) throws JSONException {
-        write(os,false);
+        write(os, false);
         return os;
     }
 
     /**
      * Convert this object into a stream of JSON text.  Same as calling write(writer,false);
      * Note that encoding is always written as UTF-8, as per JSON spec.
-     * @param os The output stream to write data to.
-     * @param verbose Whether or not to write the JSON text in a verbose format.
      *
+     * @param os      The output stream to write data to.
+     * @param verbose Whether or not to write the JSON text in a verbose format.
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public OutputStream write(OutputStream os, boolean verbose) throws JSONException {
@@ -351,7 +346,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         write(writer, verbose);
         try {
             writer.flush();
-        } catch (Exception ex) { 
+        } catch (Exception ex) {
             JSONException jex = new JSONException("Error during buffer flush");
             jex.initCause(ex);
             throw jex;
@@ -361,9 +356,9 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * Write this object to the stream as JSON text in UTF-8 encoding, specifying how many spaces should be used for each indent.
-     * @param indentDepth How many spaces to use for each indent level.  Should be one to eight.  
-     * Less than one means no intending, greater than 8 and it will just use tab.
      *
+     * @param indentDepth How many spaces to use for each indent level.  Should be one to eight.
+     *                    Less than one means no intending, greater than 8 and it will just use tab.
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public OutputStream write(OutputStream os, int indentDepth) throws JSONException {
@@ -378,7 +373,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         write(writer, indentDepth);
         try {
             writer.flush();
-        } catch (Exception ex) { 
+        } catch (Exception ex) {
             JSONException jex = new JSONException("Error during buffer flush");
             jex.initCause(ex);
             throw jex;
@@ -388,8 +383,8 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * Write this object to the writer as JSON text. Same as calling write(writer,false);
-     * @param writer The writer which to write the JSON text to.
      *
+     * @param writer The writer which to write the JSON text to.
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public Writer write(Writer writer) throws JSONException {
@@ -399,8 +394,8 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * Write this object to the writer as JSON text in UTF-8 encoding, specifying whether to use verbose (tab-indented) output or not.
-     * @param writer The writer which to write the JSON text to.
      *
+     * @param writer The writer which to write the JSON text to.
      * @throws JSONException Thrown on IO errors during serialization.
      */
     public Writer write(Writer writer, boolean verbose) throws JSONException {
@@ -411,8 +406,8 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         Class writerClass = writer.getClass();
         boolean flushIt = false;
         if (!StringWriter.class.isAssignableFrom(writerClass) &&
-            !CharArrayWriter.class.isAssignableFrom(writerClass) &&
-            !BufferedWriter.class.isAssignableFrom(writerClass)) {
+                !CharArrayWriter.class.isAssignableFrom(writerClass) &&
+                !BufferedWriter.class.isAssignableFrom(writerClass)) {
             writer = new BufferedWriter(writer);
             flushIt = true;
         }
@@ -433,7 +428,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         if (flushIt) {
             try {
                 writer.flush();
-            } catch (Exception ex) { 
+            } catch (Exception ex) {
                 JSONException jex = new JSONException("Error during buffer flush");
                 jex.initCause(ex);
                 throw jex;
@@ -443,9 +438,10 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     }
 
     /**
-     * Write this object to the writer as JSON text, specifying how many spaces should be used for each indent.  
+     * Write this object to the writer as JSON text, specifying how many spaces should be used for each indent.
      * This is an alternate indent style to using tabs.
-     * @param writer The writer which to write the JSON text to.
+     *
+     * @param writer      The writer which to write the JSON text to.
      * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.
      */
     public Writer write(Writer writer, int indentDepth) throws JSONException {
@@ -462,8 +458,8 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         Class writerClass = writer.getClass();
         boolean flushIt = false;
         if (!StringWriter.class.isAssignableFrom(writerClass) &&
-            !CharArrayWriter.class.isAssignableFrom(writerClass) &&
-            !BufferedWriter.class.isAssignableFrom(writerClass)) {
+                !CharArrayWriter.class.isAssignableFrom(writerClass) &&
+                !BufferedWriter.class.isAssignableFrom(writerClass)) {
             writer = new BufferedWriter(writer);
             flushIt = true;
         }
@@ -483,7 +479,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         if (flushIt) {
             try {
                 writer.flush();
-            } catch (Exception ex) { 
+            } catch (Exception ex) {
                 JSONException jex = new JSONException("Error during buffer flush");
                 jex.initCause(ex);
                 throw jex;
@@ -494,61 +490,67 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
 
     /**
-     * Convert this object into a String of JSON text, specifying how many spaces should be used for each indent.  
+     * Convert this object into a String of JSON text, specifying how many spaces should be used for each indent.
      * This is an alternate indent style to using tabs.
-     * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.  
-     * Less than one means no indenting, greater than 8 and it will just use tab.
      *
+     * @param indentDepth How many spaces to use for each indent.  The value should be between one to eight.
+     *                    Less than one means no indenting, greater than 8 and it will just use tab.
      * @throws JSONException Thrown on errors during serialization.
      */
     public String write(int indentDepth) throws JSONException {
-        Serializer serializer;
-        StringWriter writer = new StringWriter();
-
-        if (indentDepth < 1) {
-            indentDepth = 0;
-        } else if (indentDepth > 8) {
-            indentDepth = 9;
-        }
-
-        if (indentDepth > 0) {
-            serializer = new SerializerVerbose(writer, indentDepth);
-        } else {
-            serializer = new Serializer(writer);
-        }
-        try {
+        try (final StringWriter writer = new StringWriter()) {
+            final Serializer serializer = (indentDepth < 0)
+                    ? new Serializer(writer)
+                    : new SerializerVerbose(writer, indentDepth);
             serializer.writeObject(this).flush();
+            return writer.toString();
         } catch (IOException iox) {
             JSONException jex = new JSONException("Error occurred during write.");
             jex.initCause(iox);
             throw jex;
         }
-        return writer.toString();
+    }
+
+    /**
+     * Convert this object into a String of JSON text, specifying how many spaces should be used for each indent.
+     * This is an alternate indent style to using tabs.
+     *
+     * @param formatOptions format options
+     * @return the JSON string
+     * @throws JSONException Thrown on errors during serialization.
+     */
+    public String write(FormatOptions formatOptions) throws JSONException {
+        try (final StringWriter writer = new StringWriter()) {
+            final Serializer serializer = (formatOptions.isCompact())
+                    ? new Serializer(writer, formatOptions)
+                    : new SerializerVerbose(writer, formatOptions);
+            serializer.writeObject(this).flush();
+            return writer.toString();
+        } catch (IOException iox) {
+            JSONException jex = new JSONException("Error occurred during write.");
+            jex.initCause(iox);
+            throw jex;
+        }
     }
 
     /**
      * Convert this object into a String of JSON text, specifying whether to use verbose (tab-indented) output or not.
-     * @param verbose Whether or not to write in compressed format.
      *
+     * @param verbose Whether or not to write in compressed format.
      * @throws JSONException Thrown on errors during serialization.
      */
     public String write(boolean verbose) throws JSONException {
-        Serializer serializer;
-        StringWriter writer = new StringWriter();
-
-        if (verbose) {
-            serializer = new SerializerVerbose(writer);
-        } else {
-            serializer = new Serializer(writer);
-        }
-        try {
+        try (final StringWriter writer = new StringWriter()) {
+            final Serializer serializer = (!verbose)
+                    ? new Serializer(writer)
+                    : new SerializerVerbose(writer);
             serializer.writeObject(this).flush();
+            return writer.toString();
         } catch (IOException iox) {
             JSONException jex = new JSONException("Error occurred during write.");
             jex.initCause(iox);
             throw jex;
         }
-        return writer.toString();
     }
 
     /**
@@ -561,13 +563,14 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     }
 
     /**
-     * Method to obtain the object value for a key.  
+     * Method to obtain the object value for a key.
      * This string-based method is provided for API compatibility to other JSON models.
+     *
      * @param key The key  (attribute) name to obtain the value for.
      * @throws JSONException Thrown if the noted key is not in the map of key/value pairs.
      */
     public Object get(String key) throws JSONException {
-        Object val = this.get((Object)key);
+        Object val = this.get((Object) key);
         if (val == null) {
             if (!this.containsKey(key)) {
                 throw new JSONException("The key [" + key + "] was not in the map");
@@ -577,30 +580,32 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     }
 
     /**
-     * Method to obtain the object value for a key.  If the key is not in the map, null is returned.  
+     * Method to obtain the object value for a key.  If the key is not in the map, null is returned.
      * This string-based method is provided for API compatibility to other JSON models.
+     *
      * @param key The key  (attribute) name to obtain the value for.
      */
     public Object opt(String key) {
-        return this.get((Object)key);
+        return this.get((Object) key);
     }
 
     /**
      * (non-Javadoc)
-     * @see java.util.HashMap#put(java.lang.Object, java.lang.Object)
-     * @param key The key to put in the JSONObject
-     * @param value The value to put in the JSONObject
+     *
+     * @param key               The key to put in the JSONObject
+     * @param value             The value to put in the JSONObject
      * @param includeSuperclass Boolean indicating that if the object is a JavaBean, include superclass getter properties.
      * @throws JSONException Thrown if key is null, not a string, or the value could not be converted.
+     * @see java.util.HashMap#put(java.lang.Object, java.lang.Object)
      */
     public Object put(Object key, Object value, boolean includeSuperclass) throws JSONException {
-        if (null == key) throw new JSONException("key must not be null");
-        if (!(key instanceof String)) throw new JSONException("key must be a String");
+        if (null == key) throw new IllegalArgumentException("key must not be null");
+        if (!(key instanceof String)) throw new IllegalArgumentException("key must be a String");
         if (!isValidObject(value)) {
             // Try to convert the unknown type to a JSONObject
-            if (value != null ) {
+            if (value != null) {
                 try {
-                    value = BeanSerializer.toJson(value, includeSuperclass); 
+                    value = BeanSerializer.toJson(value, includeSuperclass);
                 } catch (Exception ex) {
                     throw new JSONException("Invalid type of value.  Could not convert type: [" + value.getClass().getName() + "]");
                 }
@@ -611,13 +616,20 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * (non-Javadoc)
+     *
      * @see java.util.HashMap#put(java.lang.Object, java.lang.Object)
      * This is the same as calling put(key, value, true);
      */
+    @Override
     public Object put(Object key, Object value) {
         try {
             return put(key, value, true);
+        } catch (JSONException jex) {
+            throw new RuntimeException(jex);
         } catch (Exception e) {
+            if (e instanceof IllegalArgumentException) {
+                throw e;
+            }
             IllegalArgumentException iae = new IllegalArgumentException("Error occurred during JSON conversion");
             iae.initCause(e);
             throw iae;
@@ -630,35 +642,38 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * Similar to default HashMap put, except it returns JSONObject instead of Object.
-     * @see java.util.HashMap#put(java.lang.Object, java.lang.Object)
+     *
      * @return A reference to this object instance.
      * @throws JSONException Thrown if key is null, not a string, or the value could not be converted to JSON.
+     * @see java.util.HashMap#put(java.lang.Object, java.lang.Object)
      */
-    public JSONObject put(String key, Object value) throws JSONException{
-        this.put((Object)key, value);
+    public JSONObject put(String key, Object value) throws JSONException {
+        this.put((Object) key, value);
         return this;
     }
 
     /**
      * Method to add an atomic boolean to the JSONObject.
      * param key The key/attribute name to set the boolean at.
+     *
      * @param value The boolean value.
-     * @throws JSONException Thrown if key is null or not a string.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown if key is null or not a string.
      */
-    public JSONObject put(String key, boolean value) throws JSONException{
-        this.put(key,new Boolean(value));
+    public JSONObject put(String key, boolean value) throws JSONException {
+        this.put(key, new Boolean(value));
         return this;
     }
 
     /**
      * Method to add an atomic double to the JSONObject.
      * param key The key/attribute name to set the double at.
+     *
      * @param value The double value.
-     * @throws JSONException Thrown if key is null or not a string.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown if key is null or not a string.
      */
-    public JSONObject put(String key, double value) throws JSONException{
+    public JSONObject put(String key, double value) throws JSONException {
         this.put(key, new Double(value));
         return this;
     }
@@ -666,11 +681,12 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Method to add an atomic integer to the JSONObject.
      * param key The key/attribute name to set the integer at.
+     *
      * @param value The integer value.
-     * @throws JSONException Thrown if key is null or not a string.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown if key is null or not a string.
      */
-    public JSONObject put(String key, int value) throws JSONException{
+    public JSONObject put(String key, int value) throws JSONException {
         this.put(key, new Integer(value));
         return this;
     }
@@ -678,41 +694,44 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Method to add an atomic short to the JSONObject.
      * param key The key/attribute name to set the integer at.
+     *
      * @param value The integer value.
-     * @throws JSONException Thrown if key is null or not a string.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown if key is null or not a string.
      */
-    public JSONObject put(String key, short value) throws JSONException{
+    public JSONObject put(String key, short value) throws JSONException {
         this.put(key, new Short(value));
         return this;
     }
 
     /**
      * Method to add an atomic long to the JSONObject.
-     * @param key The key/attribute name to set the long to.
+     *
+     * @param key   The key/attribute name to set the long to.
      * @param value The long value.
-     * @throws JSONException Thrown if key is null or not a string.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown if key is null or not a string.
      */
-    public JSONObject put(String key, long value) throws JSONException{
+    public JSONObject put(String key, long value) throws JSONException {
         this.put(key, new Long(value));
         return this;
     }
 
     /**
      * Method to add a Map as a new JSONObject contained in this JSONObject
-     * @param key The key/attribute name to set the new JSONObject to.
-     * @param value The Map object to convert to a JSONObject and store.
+     *
+     * @param key               The key/attribute name to set the new JSONObject to.
+     * @param value             The Map object to convert to a JSONObject and store.
      * @param includeSuperclass For values of the map which are JavaBeans and are converted, include superclass getter properties.
-     * @throws JSONException Thrown when contents in the map cannot be converted to something JSONable.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown when contents in the map cannot be converted to something JSONable.
      */
     public JSONObject put(String key, Map value, boolean includeSuperclass) throws JSONException {
         if (value == null) {
-            this.put(key, (Object)null);
+            this.put(key, (Object) null);
         } else {
             if (JSONObject.class.isAssignableFrom(value.getClass())) {
-                this.put(key, (Object)value);
+                this.put(key, (Object) value);
             } else {
                 this.put(key, new JSONObject(value, includeSuperclass));
             }
@@ -723,29 +742,31 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Method to add a Map as a new JSONObject contained in this JSONObject
      * Same as calling put(String, Map, true);
-     * @param key The key/attribute name to set the new JSONObject to.
+     *
+     * @param key   The key/attribute name to set the new JSONObject to.
      * @param value The Map object to convert to a JSONObject and store.
-     * @throws JSONException Thrown when contents in the map cannot be converted to something JSONable.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown when contents in the map cannot be converted to something JSONable.
      */
     public JSONObject put(String key, Map value) throws JSONException {
-        return put(key,value,true);
+        return put(key, value, true);
     }
 
     /**
      * Method to add a Collection as a new JSONArray contained in this JSONObject
-     * @param key The key/attribute name to set the collection to.
-     * @param value The Map object to convert to a JSONObject and store.
+     *
+     * @param key               The key/attribute name to set the collection to.
+     * @param value             The Map object to convert to a JSONObject and store.
      * @param includeSuperclass For values of the map which are JavaBeans and are converted, include superclass getter properties.
-     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
      */
     public JSONObject put(String key, Collection value, boolean includeSuperclass) throws JSONException {
         if (value == null) {
-            this.put(key, (Object)null);
+            this.put(key, (Object) null);
         } else {
             if (JSONArray.class.isAssignableFrom(value.getClass())) {
-                this.put(key, (Object)value);
+                this.put(key, (Object) value);
             } else {
                 this.put(key, new JSONArray(value, includeSuperclass));
             }
@@ -755,62 +776,66 @@ public class JSONObject extends HashMap  implements JSONArtifact {
 
     /**
      * Method to add a Collection as a new JSONArray contained in this JSONObject
-     * @param key The key/attribute name to set the collection to.
+     *
+     * @param key   The key/attribute name to set the collection to.
      * @param value The Map object to convert to a JSONObject and store.
-     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
      */
     public JSONObject put(String key, Collection value) throws JSONException {
-        return put(key,value,true);
+        return put(key, value, true);
     }
-    
+
     /**
      * Method to add an Object array as a new JSONArray contained in this JSONObject
-     * @param key The key/attribute name to set the collection to.
+     *
+     * @param key   The key/attribute name to set the collection to.
      * @param value The Object array to convert to a JSONArray and store.
-     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
      */
-     public JSONObject put(String key, Object[] value) throws JSONException {
-     	 return put (key, new JSONArray(value), true);
-     }
-     
-     /**
-      * Method to add an Object array as a new JSONArray contained in this JSONObject
-      * @param key The key/attribute name to set the collection to.
-      * @param value The Object array to convert to a JSONArray and store.
-      * @param includeSuperclass For values of the Object array which are JavaBeans and are converted, include superclass getter properties.
-      * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
-      * @return A reference to this object instance.
-      */
-      public JSONObject put(String key, Object[] value, boolean includeSuperclass) throws JSONException {
-   	      return put (key, new JSONArray(value), includeSuperclass);
-      }
+    public JSONObject put(String key, Object[] value) throws JSONException {
+        return put(key, new JSONArray(value), true);
+    }
+
+    /**
+     * Method to add an Object array as a new JSONArray contained in this JSONObject
+     *
+     * @param key               The key/attribute name to set the collection to.
+     * @param value             The Object array to convert to a JSONArray and store.
+     * @param includeSuperclass For values of the Object array which are JavaBeans and are converted, include superclass getter properties.
+     * @return A reference to this object instance.
+     * @throws JSONException Thrown when contents in the Collection cannot be converted to something JSONable.
+     */
+    public JSONObject put(String key, Object[] value, boolean includeSuperclass) throws JSONException {
+        return put(key, new JSONArray(value), includeSuperclass);
+    }
 
     /**
      * Utility method to obtain the specified key as a 'boolean' value
      * Only boolean true, false, and the String true and false will return.  In this case null, the number 0, and empty string should be treated as false.
      * everything else is true.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a boolean instance, or the strings 'true' or 'false'.
+     *            throws JSONException Thrown when the type returned by get(key) is not a boolean instance, or the strings 'true' or 'false'.
      * @return A boolean value (true or false), if the value stored for key is a Boolean, or the strings 'true' or 'false'.
-     */ 
+     */
     public boolean getBoolean(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (val instanceof Boolean) {
-                return((Boolean)val).booleanValue();
+                return ((Boolean) val).booleanValue();
             } else if (Number.class.isAssignableFrom(val.getClass())) {
                 throw new JSONException("Value at key: [" + key + "] was not a boolean or string value of 'true' or 'false'.");
             } else if (String.class.isAssignableFrom(val.getClass())) {
-                String str = (String)val;
+                String str = (String) val;
                 if (str.equals("true")) {
                     return true;
                 } else if (str.equals("false")) {
                     return false;
                 } else {
-                    throw new JSONException("The value for key: [" + key + "]: [" + str + "] was not 'true' or 'false'");    
+                    throw new JSONException("The value for key: [" + key + "]: [" + str + "] was not 'true' or 'false'");
                 }
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a type that can be converted to boolean");
@@ -824,18 +849,19 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'boolean' value
      * Only returns true if the value is boolean true or the string 'true'.  All other values return false.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
      * @return A boolean value (true or false), if the value stored for key is a Boolean, or the strings 'true' or 'false'.
-     */ 
+     */
     public boolean optBoolean(String key) {
         Object val = this.opt(key);
         if (val != null) {
             if (val instanceof Boolean) {
-                return((Boolean)val).booleanValue();
+                return ((Boolean) val).booleanValue();
             } else if (Number.class.isAssignableFrom(val.getClass())) {
                 return false;
             } else if (String.class.isAssignableFrom(val.getClass())) {
-                String str = (String)val;
+                String str = (String) val;
                 if (str.equals("true")) {
                     return true;
                 } else {
@@ -853,19 +879,20 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'boolean' value
      * Only returns true if the value is boolean true or the string 'true'.  All other values return false.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default value to return.
      * @return A boolean value (true or false), if the value stored for key is a Boolean, or the strings 'true' or 'false'.
-     */ 
+     */
     public boolean optBoolean(String key, boolean defaultValue) {
         Object val = this.opt(key);
         if (val != null) {
             if (val instanceof Boolean) {
-                return((Boolean)val).booleanValue();
+                return ((Boolean) val).booleanValue();
             } else if (Number.class.isAssignableFrom(val.getClass())) {
                 return false;
             } else if (String.class.isAssignableFrom(val.getClass())) {
-                String str = (String)val;
+                String str = (String) val;
                 if (str.equals("true")) {
                     return true;
                 } else if (str.equals("false")) {
@@ -886,15 +913,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'double' value
      * Only values of Number will be converted to double, all other types will generate an exception
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a Double instance, or cannot be converted to a double.
+     *            throws JSONException Thrown when the type returned by get(key) is not a Double instance, or cannot be converted to a double.
      * @return A double value if the value stored for key is an instance of Number.
-     */ 
+     */
     public double getDouble(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).doubleValue();
+                return ((Number) val).doubleValue();
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a type that can be converted to double");
             }
@@ -906,16 +934,17 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Utility method to obtain the specified key as a 'double' value
      * Only values of Number will be converted to double.  all other values
-     * will return <code>Double.NaN.</code>
+     * will return <tt>Double.NaN.</tt>
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
      * @return A double value if the value stored for key is an instance of Number
-     */ 
+     */
     public double optDouble(String key) {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).doubleValue();
+                return ((Number) val).doubleValue();
             }
         }
         return Double.NaN;
@@ -924,17 +953,18 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Utility method to obtain the specified key as a 'double' value
      * Only values of Number will be converted to double.  all other
-     * values will return <code></code>Double.NaN.
+     * values will return <tt></tt>Double.NaN.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default double value to return in case of NaN/null values in map.
      * @return A double value if the value stored for key is an instance of Number.
-     */ 
+     */
     public double optDouble(String key, double defaultValue) {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).doubleValue();
+                return ((Number) val).doubleValue();
             }
         }
         return defaultValue;
@@ -944,15 +974,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'short' value
      * Only values of Number will be converted to short, all other types will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a Short instance, or cannot be converted to a short.
+     *            throws JSONException Thrown when the type returned by get(key) is not a Short instance, or cannot be converted to a short.
      * @return A short value if the value stored for key is an instance of Number.
-     */ 
+     */
     public short getShort(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).shortValue();
+                return ((Number) val).shortValue();
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a type that can be converted to short");
             }
@@ -965,32 +996,34 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'short' value
      * Only values of Number will be converted to short.  All other types return 0.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
      * @return A short value if the value stored for key is an instance of Number.  0 otherwise.
-     */ 
+     */
     public short optShort(String key) {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).shortValue();
+                return ((Number) val).shortValue();
             }
         }
-        return(short)0;
+        return (short) 0;
     }
 
     /**
      * Utility method to obtain the specified key as a 'short' value
-     * Only values of Number will be converted to short.  
+     * Only values of Number will be converted to short.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default value to return in the case of null/nonNumber values in the map.
      * @return A short value if the value stored for key is an instance of Number.  0 otherwise.
-     */ 
+     */
     public short optShort(String key, short defaultValue) {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).shortValue();
+                return ((Number) val).shortValue();
             }
         }
         return defaultValue;
@@ -1000,15 +1033,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'int' value
      * Only values of Number will be converted to integer, all other types will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a Double instance, or cannot be converted to a double.
+     *            throws JSONException Thrown when the type returned by get(key) is not a Double instance, or cannot be converted to a double.
      * @return A int value if the value stored for key is an instance of Number.
-     */ 
+     */
     public int getInt(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).intValue();
+                return ((Number) val).intValue();
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a type that can be converted to integer");
             }
@@ -1021,14 +1055,15 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'int' value
      * Provided for compatibility to other JSON models.
      * Only values of Number will be converted to integer, all other types will return 0.
+     *
      * @param key The key to look up.
      * @return A int value if the value stored for key is an instance of Number.  0 otherwise.
-     */ 
+     */
     public int optInt(String key) {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).intValue();
+                return ((Number) val).intValue();
             }
         }
         return 0;
@@ -1038,15 +1073,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'int' value
      * Provided for compatibility to other JSON models.
      * Only values of Number will be converted to integer
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default int value to return in case of null/non-number values in the map.
      * @return A int value if the value stored for key is an instance of Number.
-     */ 
+     */
     public int optInt(String key, int defaultValue) {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).intValue();
+                return ((Number) val).intValue();
             }
         }
         return defaultValue;
@@ -1056,15 +1092,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'long' value
      * Only values of Number will be converted to long, all other types will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a Long instance, or cannot be converted to a long..
+     *            throws JSONException Thrown when the type returned by get(key) is not a Long instance, or cannot be converted to a long..
      * @return A long value if the value stored for key is an instance of Number.
-     */ 
+     */
     public long getLong(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).longValue();
+                return ((Number) val).longValue();
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a type that can be converted to long");
             }
@@ -1077,32 +1114,34 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'long' value
      * Only values of Number will be converted to long.  all other types return 0.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
      * @return A long value if the value stored for key is an instance of Number, 0 otherwise.
-     */ 
+     */
     public long optLong(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).longValue();
+                return ((Number) val).longValue();
             }
         }
-        return(long)0;
+        return (long) 0;
     }
 
     /**
      * Utility method to obtain the specified key as a 'long' value
      * Only values of Number will be converted to long.  all other types return 0.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default long value to return in case of null/non Number values in the map.
      * @return A long value if the value stored for key is an instance of Number, defaultValue otherwise.
-     */ 
+     */
     public long optLong(String key, long defaultValue) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (Number.class.isAssignableFrom(val.getClass())) {
-                return((Number)val).intValue();
+                return ((Number) val).intValue();
             }
         }
         return defaultValue;
@@ -1112,10 +1151,11 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'string' value
      * Only values that can be easily converted to string will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is null.
+     *            throws JSONException Thrown when the type returned by get(key) is null.
      * @return A string value if the value if the value stored for key is not null.
-     */ 
+     */
     public String getString(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
@@ -1129,10 +1169,11 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'string' value
      * Only values that can be easily converted to string will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is null.
+     *            throws JSONException Thrown when the type returned by get(key) is null.
      * @return A string value if the value if the value stored for key is not null.
-     */ 
+     */
     public String optString(String key) {
         Object val = this.opt(key);
         if (val != null) {
@@ -1145,10 +1186,11 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a 'string' value
      * Only values that can be easily converted to string will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default String value to return in the case of null values in the map.
      * @return A string value if the value if the value stored for key is not null, defaultValue otherwise.
-     */ 
+     */
     public String optString(String key, String defaultValue) {
         Object val = this.opt(key);
         if (val != null) {
@@ -1161,15 +1203,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a JSONObject
      * Only values that are instances of JSONObject will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a JSONObject instance.
+     *            throws JSONException Thrown when the type returned by get(key) is not a JSONObject instance.
      * @return A JSONObject value if the value stored for key is an instance or subclass of JSONObject.
-     */ 
+     */
     public JSONObject getJSONObject(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (JSONObject.class.isAssignableFrom(val.getClass())) {
-                return(JSONObject)val;
+                return (JSONObject) val;
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a JSONObject");
             }
@@ -1182,14 +1225,15 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a JSONObject
      * Only values that are instances of JSONObject will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
      * @return A JSONObject value if the value stored for key is an instance or subclass of JSONObject, null otherwise.
-     */ 
+     */
     public JSONObject optJSONObject(String key) {
         Object val = this.opt(key);
         if (val != null) {
             if (JSONObject.class.isAssignableFrom(val.getClass())) {
-                return(JSONObject)val;
+                return (JSONObject) val;
             }
         }
         return null;
@@ -1199,15 +1243,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a JSONObject
      * Only values that are instances of JSONObject will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default JSONObject to return in the case of null/non JSONObject values in the map.
      * @return A JSONObject value if the value stored for key is an instance or subclass of JSONObject, defaultValue otherwise.
-     */ 
+     */
     public JSONObject optJSONObject(String key, JSONObject defaultValue) {
         Object val = this.opt(key);
         if (val != null) {
             if (JSONObject.class.isAssignableFrom(val.getClass())) {
-                return(JSONObject)val;
+                return (JSONObject) val;
             }
         }
         return defaultValue;
@@ -1217,15 +1262,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a JSONArray
      * Only values that are instances of JSONArray will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
-     * throws JSONException Thrown when the type returned by get(key) is not a Long instance, or cannot be converted to a long..
+     *            throws JSONException Thrown when the type returned by get(key) is not a Long instance, or cannot be converted to a long..
      * @return A JSONArray value if the value stored for key is an instance or subclass of JSONArray.
-     */ 
+     */
     public JSONArray getJSONArray(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (JSONArray.class.isAssignableFrom(val.getClass())) {
-                return(JSONArray)val;
+                return (JSONArray) val;
             } else {
                 throw new JSONException("The value for key: [" + key + "] was not a JSONObject");
             }
@@ -1238,14 +1284,15 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a JSONArray
      * Only values that are instances of JSONArray will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
+     *
      * @param key The key to look up.
      * @return A JSONArray value if the value stored for key is an instance or subclass of JSONArray, null otherwise.
-     */ 
+     */
     public JSONArray optJSONArray(String key) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (JSONArray.class.isAssignableFrom(val.getClass())) {
-                return(JSONArray)val;
+                return (JSONArray) val;
             }
         }
         return null;
@@ -1255,15 +1302,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Utility method to obtain the specified key as a JSONArray
      * Only values that are instances of JSONArray will be returned.  A null will generate an exception.
      * Provided for compatibility to other JSON models.
-     * @param key The key to look up.
+     *
+     * @param key          The key to look up.
      * @param defaultValue The default value to return if the value in the map is null/not a JSONArray.
      * @return A JSONArray value if the value stored for key is an instance or subclass of JSONArray, defaultValue otherwise.
-     */ 
+     */
     public JSONArray optJSONArray(String key, JSONArray defaultValue) throws JSONException {
         Object val = this.opt(key);
         if (val != null) {
             if (JSONArray.class.isAssignableFrom(val.getClass())) {
-                return(JSONArray)val;
+                return (JSONArray) val;
             }
         }
         return defaultValue;
@@ -1273,7 +1321,8 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Put a key/value pair into the JSONObject, but only if key/value are both not null, and only if the key is not present already.
      * Provided for compatibility to existing models.
-     * @param key The ket to place in the array
+     *
+     * @param key   The ket to place in the array
      * @param value The value to place in the array
      * @return Reference to the current JSONObject.
      * @throws JSONException - Thrown if the key already exists or if key or value is null
@@ -1288,16 +1337,17 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         if (this.containsKey(key)) {
             throw new JSONException("Key [" + key + "] already exists in the map");
         }
-        this.put(key,value);
+        this.put(key, value);
         return this;
     }
 
     /**
      * Put a key/value pair into the JSONObject, but only if the key and value are non-null.
-     * @param key The keey (attribute) name to assign to the value.
+     *
+     * @param key   The keey (attribute) name to assign to the value.
      * @param value The value to put into the JSONObject.
      * @return Reference to the current JSONObject.
-     * @throws JSONException - if the value is a non-finite number 
+     * @throws JSONException - if the value is a non-finite number
      */
     public JSONObject putOpt(String key, Object value) throws JSONException {
         if (key == null) {
@@ -1306,14 +1356,15 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         if (value == null) {
             throw new JSONException("Value cannot be null");
         }
-        this.put(key,value);
+        this.put(key, value);
         return this;
     }
 
 
-    /** 
+    /**
      * Method to return the number of keys in this JSONObject.
      * This function merely maps to HashMap.size().  Provided for API compatibility.
+     *
      * @return returns the number of keys in the JSONObject.
      */
     public int length() {
@@ -1324,44 +1375,42 @@ public class JSONObject extends HashMap  implements JSONArtifact {
      * Method to append the 'value' object to the element at entry 'key'.
      * If JSONObject.has(key) returns false, a new array is created and the value is appended to it.
      * If the object at position key is not an array, then a new JSONArray is created
-     * and both current and new values are appended to it, then the value of the attribute is set to the new 
+     * and both current and new values are appended to it, then the value of the attribute is set to the new
      * array.  If the current value is already an array, then 'value' is added to it.
      *
-     * @param key The key/attribute name to append to.
+     * @param key   The key/attribute name to append to.
      * @param value The value to append to it.
-     *
-     * @throws JSONException Thrown if the value to append is not JSONAble.
      * @return A reference to this object instance.
+     * @throws JSONException Thrown if the value to append is not JSONAble.
      */
     public JSONObject append(String key, Object value) throws JSONException {
-    	JSONArray array = null;
-    	if (!this.has(key)) {
-    		  array = new JSONArray();
-    	}
-    	else {
+        JSONArray array = null;
+        if (!this.has(key)) {
+            array = new JSONArray();
+        } else {
             Object oldVal = this.get(key);
-            array = new JSONArray();   
+            array = new JSONArray();
             if (oldVal == null) {
                 // Add a null if the key was actually there, but just
                 // had value of null.
-      		           
+
                 array.add(null);
-        	}
-            else  if (JSONArray.class.isAssignableFrom(oldVal.getClass())) {
-	            array = (JSONArray)oldVal;
-	        } else {
-	            array = new JSONArray();
-	            array.add(oldVal);
-	            
+            } else if (JSONArray.class.isAssignableFrom(oldVal.getClass())) {
+                array = (JSONArray) oldVal;
+            } else {
+                array = new JSONArray();
+                array.add(oldVal);
+
             }
-          
-    	}
+
+        }
         array.add(value);
-        return put(key,array);
+        return put(key, array);
     }
 
     /**
      * Produce a JSONArray containing the values of the members of this JSONObject
+     *
      * @param names - A JSONArray containing the a list of key strings.  This determines the sequence of values in the result.
      * @return A JSONArray of the values found for the names provided.
      * @throws JSONException - if errors occur during storing the values in a JSONArray
@@ -1376,8 +1425,9 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     }
 
 
-    /** 
+    /**
      * Method to test if a key exists in the JSONObject.
+     *
      * @param key The key to test.
      * @return true if the key is defined in the JSONObject (regardless of value), or false if the key is not in the JSONObject
      */
@@ -1388,33 +1438,50 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         return false;
     }
 
-    /** 
-     * Method to test if a key is mapped to null.  
+    /**
+     * Method to test if a key is mapped to null.
      * This method will also return true if the key has not been put in the JSONObject yet.
+     *
      * @param key The key to test for null.
      * @return true if the key is not in the map or if the value referenced by the key is null.
      */
     public boolean isNull(String key) {
-        if ( (this.opt(key) == null) || (NULL == this.opt(key)) ) {
+        if ((this.opt(key) == null) || (NULL == this.opt(key))) {
             return true;
         }
         return false;
     }
 
-    /** 
+    /**
      * Utility function that returns an iterator of all the keys (attributes) of this JSONObject
+     *
      * @return An iterator of all keys in the object.
      */
-    public Iterator keys() {
-        Set set = this.keySet();
-        if (set != null) {
-            return set.iterator();
+    public Iterator<String> keys() {
+        Set<String> set = this.keySet();
+        if (null == set) {
+            return null;
         }
-        return null;
+        return set.iterator();
     }
 
-    /** 
+    /**
+     * Sorts the keys using default string ordering
+     * @return - iterator
+     */
+    public Iterator<String> orderedKeys() {
+        Set<String> set = this.keySet();
+        if (null == set) {
+            return null;
+        }
+        ArrayList<String> keys = new ArrayList<>(set);
+        keys.sort(String::compareTo);
+        return keys.iterator();
+    }
+
+    /**
      * Utility function that returns a JSONArray of all the names of the keys (attributes) of this JSONObject
+     *
      * @return All the keys in the JSONObject as a JSONArray.
      */
     public JSONArray names() {
@@ -1429,8 +1496,9 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         return null;
     }
 
-    /** 
+    /**
      * Utility function that returns a String[] of all the names of the keys (attributes) of this JSONObject
+     *
      * @return All the keys in the JSONObject as a String[].
      */
     public static String[] getNames(JSONObject obj) {
@@ -1442,7 +1510,7 @@ public class JSONObject extends HashMap  implements JSONArtifact {
                 Iterator itr = obj.keys();
                 if (itr != null) {
                     while (itr.hasNext()) {
-                        array[pos] = (String)itr.next();
+                        array[pos] = (String) itr.next();
                         pos++;
                     }
                 }
@@ -1451,8 +1519,9 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         return array;
     }
 
-    /** 
+    /**
      * Utility function that returns an iterator of all the keys (attributes) of this JSONObject sorted in lexicographic manner (String.compareTo).
+     *
      * @return An iterator of all keys in the object in lexicographic (character code) sorted order.
      */
     public Iterator sortedKeys() {
@@ -1474,14 +1543,16 @@ public class JSONObject extends HashMap  implements JSONArtifact {
         return null;
     }
 
-    /**
-     * End of convenience methods.
-     */
+    /* *************************** */
+    /* End of convenience methods. */
+    /* *************************** */
 
     /**
      * Over-ridden toString() method.  Returns the same value as write(), which is a compact JSON String.
      * If an error occurs in the serialization, the return will be of format: JSON Generation Error: [<some error>]
+     *
      * @return A string of JSON text, if possible.
+     * @see #write()
      */
     public String toString() {
         return toString(false);
@@ -1490,25 +1561,43 @@ public class JSONObject extends HashMap  implements JSONArtifact {
     /**
      * Verbose capable toString method.
      * If an error occurs in the serialization, the return will be of format: JSON Generation Error: [<some error>]
+     *
      * @param verbose Whether or not to tab-indent the output.
      * @return A string of JSON text, if possible.
+     * @see #write(boolean)
      */
     public String toString(boolean verbose) {
-        String str = null;
         try {
-            str = write(verbose);    
+            return write(verbose);
         } catch (JSONException jex) {
-            str = "JSON Generation Error: [" + jex.toString() + "]";
+            return "JSON Generation Error: [" + jex.toString() + "]";
         }
-        return str;
     }
 
     /**
      * Function to return a string of JSON text with specified indention.  Returns the same value as write(indentDepth).
-     * If an error occurs in the serialization, a JSONException is thrown.
+     * If an error occurs in the serialization, a <tt>JSONException</tt> is thrown.
+     *
      * @return A string of JSON text, if possible.
+     * @see #write(int)
      */
     public String toString(int indentDepth) throws JSONException {
         return write(indentDepth);
+    }
+
+    /**
+     * Function to return a string of JSON text using the passed format options.
+     * If an error occurs in the serialization, a <tt>JSONException</tt> is thrown.
+     *
+     * @param formatOptions format options
+     * @return A string of JSON test, if  possible
+     * @see #write(FormatOptions)
+     */
+    public String toString(FormatOptions formatOptions) {
+        try {
+            return write(formatOptions);
+        } catch (JSONException jex) {
+            return "JSON Generation Error: [" + jex.toString() + "]";
+        }
     }
 }

--- a/src/main/java/org/apache/wink/json4j/OrderedJSONObject.java
+++ b/src/main/java/org/apache/wink/json4j/OrderedJSONObject.java
@@ -203,7 +203,7 @@ public class OrderedJSONObject extends JSONObject {
 
     /**
      * Method to remove an entry from the OrderedJSONObject instance.  The
-     * key cannot be <tt>null</
+     * key cannot be <tt>null</tt>
      *
      * @param key key of the object to be removed
      * @return - object that was removed

--- a/src/main/java/org/apache/wink/json4j/OrderedJSONObject.java
+++ b/src/main/java/org/apache/wink/json4j/OrderedJSONObject.java
@@ -19,21 +19,19 @@
 
 package org.apache.wink.json4j;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
+import org.apache.wink.json4j.internal.Parser;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.wink.json4j.internal.Parser;
-
 /**
- * Extension of the basic JSONObject.  This class allows control of the serialization order of attributes.  
+ * Extension of the basic JSONObject.  This class allows control of the serialization order of attributes.
  * The order in which items are put into the instance controls the order in which they are serialized out.  For example, the
- * last item put is the last item serialized.  
+ * last item put is the last item serialized.
  * <BR><BR>
  * JSON-able values are: null, and instances of String, Boolean, Number, JSONObject and JSONArray.
  * <BR><BR>
@@ -42,65 +40,68 @@ import org.apache.wink.json4j.internal.Parser;
 public class OrderedJSONObject extends JSONObject {
 
     private static final long serialVersionUID = -3269263069889337299L;
-    private ArrayList order                    = null;
+    private final ArrayList<String> order;
 
     /**
-     * Create a new instance of this class. 
+     * Create a new instance of this class.
      */
     public OrderedJSONObject() {
         super();
-        this.order = new ArrayList();
+        this.order = new ArrayList<>();
     }
 
     /**
      * Create a new instance of this class from the provided JSON object string.
      * Note:  This is the same as calling new OrderedJSONObject(str, false).
+     *
      * @param str The String of JSON to parse
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
     public OrderedJSONObject(String str) throws JSONException {
-        super();
-        this.order = new ArrayList();
-        StringReader reader = new StringReader(str);
-        (new Parser(reader)).parse(true, this);
+        this(str, false);
     }
 
     /**
      * Create a new instance of this class from the provided JSON object string.
-     * @param str The String of JSON to parse
+     *
+     * @param str    The String of JSON to parse
      * @param strict Boolean flag indicating if strict mode should be used.  Strict mode means comments and unquoted strings are not allowed.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
+    @SuppressWarnings("EmptyFinallyBlock")
     public OrderedJSONObject(String str, boolean strict) throws JSONException {
         super();
-        this.order = new ArrayList();
-        StringReader reader = new StringReader(str);
-        (new Parser(reader, strict)).parse(true, this);
+        this.order = new ArrayList<>();
+        try (StringReader reader = new StringReader(str)) {
+            (new Parser(reader, strict)).parse(true, this);
+        } finally {
+            /* */
+        }
     }
 
     /**
      * Create a new instance of this class from the data provided from the reader.  The reader content must be a JSON object string.
      * Note:  The reader will not be closed, that is left to the caller.
      * Note:  This is the same as calling new OrderedJSONObject(rdr, false).
+     *
      * @param rdr The reader from which to read the JSON to parse
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
     public OrderedJSONObject(Reader rdr) throws JSONException {
-        super();
-        this.order = new ArrayList();
-        (new Parser(rdr)).parse(true, this);
+        this(rdr, false);
     }
 
     /**
      * Create a new instance of this class from the data provided from the reader.  The reader content must be a JSON object string.
      * Note:  The reader will not be closed, that is left to the caller.
-     * @param rdr The reader from which to read the JSON to parse
+     *
+     * @param rdr    The reader from which to read the JSON to parse
      * @param strict Boolean flag indicating if strict mode should be used.  Strict mode means comments and unquoted strings are not allowed.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
     public OrderedJSONObject(Reader rdr, boolean strict) throws JSONException {
         super();
-        this.order = new ArrayList();
+        this.order = new ArrayList<>();
         (new Parser(rdr, strict)).parse(true, this);
     }
 
@@ -109,59 +110,49 @@ public class OrderedJSONObject extends JSONObject {
      * Note:  The input stream content is assumed to be UTF-8 encoded.
      * Note:  The InputStream will not be closed, that is left to the caller.
      * Note:  This is the same as calling new OrderedJSONObject(is, false).
+     *
      * @param is The InputStream from which to read the JSON to parse
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
-    public OrderedJSONObject (InputStream is) throws JSONException {
-        super();
-        this.order = new ArrayList();
-        InputStreamReader isr = null;
-        if (is != null) {
-            try {
-                isr = new InputStreamReader(is, "UTF-8");
-            } catch (Exception ex) {
-                isr = new InputStreamReader(is);
-            }
-        } else {
-            throw new JSONException("Inputstream cannot be null");
-        }
-        (new Parser(isr)).parse(true, this);
+    public OrderedJSONObject(InputStream is) throws JSONException {
+        this(is, false);
     }
 
     /**
      * Create a new instance of this class from the data provided from the input stream.  The stream content must be a JSON object string.
      * Note:  The input stream content is assumed to be UTF-8 encoded.
      * Note:  The InputStream will not be closed, that is left to the caller.
-     * @param is The InputStream from which to read the JSON to parse
+     *
+     * @param is     The InputStream from which to read the JSON to parse
      * @param strict Boolean flag indicating if strict mode should be used.  Strict mode means comments and unquoted strings are not allowed.
-     * @throws JSONException Thrown when the string passed is null, or malformed JSON.. 
+     * @throws JSONException Thrown when the string passed is null, or malformed JSON..
      */
-    public OrderedJSONObject (InputStream is, boolean strict) throws JSONException {
+    public OrderedJSONObject(InputStream is, boolean strict) throws JSONException {
         super();
-        this.order = new ArrayList();
-        InputStreamReader isr = null;
-        if (is != null) {
-            try {
-                isr = new InputStreamReader(is, "UTF-8");
-            } catch (Exception ex) {
-                isr = new InputStreamReader(is);
-            }
-        } else {
-            throw new JSONException("Inputstream cannot be null");
+        if (null == is) {
+            throw new JSONException("InputStream cannot be null");
         }
-        (new Parser(isr, strict)).parse(true, this);
+        this.order = new ArrayList<>();
+        try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+            (new Parser(isr, strict)).parse(true, this);
+        } catch (IOException ioe) {
+            final JSONException jEx = new JSONException("Failed to parse inputstram");
+            jEx.initCause(ioe);
+            throw jEx;
+        }
     }
 
     /**
-     * Create a new instance of this class using the contents of the provided map.  
+     * Create a new instance of this class using the contents of the provided map.
      * The contents of the map should be values considered JSONable.
+     *
      * @param map The map of key/value pairs to insert into this JSON object
-     * @throws JSONException Thrown when contents in the map cannot be made JSONable.
+     * @throws JSONException        Thrown when contents in the map cannot be made JSONable.
      * @throws NullPointerException Thrown if the map is null, or a key in the map is null..
      */
     public OrderedJSONObject(Map map) throws JSONException {
         super();
-        this.order = new ArrayList();
+        this.order = new ArrayList<>();
         Set set = map.keySet();
         if (set != null) {
             Iterator itr = set.iterator();
@@ -176,83 +167,81 @@ public class OrderedJSONObject extends JSONObject {
     }
 
     /**
-     * Method to put a JSON'able object into the instance.  Note that the order of initial puts controls the order of serialization.  
+     * Method to put a JSON'able object into the instance.  Note that the order of initial puts controls the order of serialization.
      * Meaning that the first time an item is put into the object determines is position of serialization.  Subsequent puts with the same
-     * key replace the existing entry value and leave serialization position alone.  For moving the position, the object must be removed, 
+     * key replace the existing entry value and leave serialization position alone.  For moving the position, the object must be removed,
      * then re-put.
+     *
      * @see java.util.HashMap#put(java.lang.Object, java.lang.Object)
      */
+    @Override
     public Object put(Object key, Object value) {
-        if (null == key) throw new IllegalArgumentException("key must not be null");
-        if (!(key instanceof String)) throw new IllegalArgumentException("key must be a String");
-
-        if (!isValidObject(value)) {
-            if (value != null) {
-                throw new IllegalArgumentException("Invalid type of value.  Type: [" + value.getClass().getName() + "] with value: [" + value.toString() + "]");
-            } else {
-                throw new IllegalArgumentException("Invalid type of value.");
-            }
+        Object val = super.put(key, value);
+        if (!this.order.contains(key)) {
+            this.order.add((String)key);
         }
-
-        /**
-         * Only put it in the ordering list if it isn't already present.
-         */
-        if (!this.containsKey(key)) {
-            this.order.add(key);
-        }
-        return super.put(key, value);
+        return val;
     }
 
     /**
-     * Method to remove an entry from the OrderedJSONObject instance.
+     * Returns the ordered set of keys for this object
+     * @return - ordered set of keys
+     */
+    @Override
+    public Iterator<String> keys() {
+        return orderedKeys();
+    }
+
+    /**
+     * Returns the ordered set of keys for this object
+     * @return - ordered set of keys
+     */
+    @Override
+    public Iterator<String> orderedKeys() {
+        return this.order.iterator();
+    }
+
+    /**
+     * Method to remove an entry from the OrderedJSONObject instance.  The
+     * key cannot be <tt>null</
+     *
+     * @param key key of the object to be removed
+     * @return - object that was removed
      * @see java.util.HashMap#remove(java.lang.Object)
      */
+    @Override
     public Object remove(Object key) {
-        Object retVal = null;
-
-        if (null == key) throw new IllegalArgumentException("key must not be null");
-        if (this.containsKey(key)) {
-            retVal = super.remove(key);
-
-            for (int i = 0; i < this.order.size(); i++) {
-                Object obj = this.order.get(i);
-                if (obj.equals(key)) {
-                    this.order.remove(i);
-                    break;
-                }
-            }
-        }
+        Object retVal = super.remove(key);
+        this.order.removeIf(key::equals);
         return retVal;
     }
 
     /**
      * (non-Javadoc)
+     *
      * @see java.util.HashMap#clear()
      */
+    @Override
     public void clear() {
         super.clear();
         this.order.clear();
     }
 
-    /** 
+    /**
      * Returns a shallow copy of this HashMap instance: the keys and values themselves are not cloned.
      */
+    @Override
     public Object clone() {
-        OrderedJSONObject clone = (OrderedJSONObject)super.clone();
-        Iterator order = clone.getOrder();
-        ArrayList orderList = new ArrayList();
-        while (order.hasNext()) {
-            orderList.add(order.next());
-            clone.order = orderList;
+        try {
+            final OrderedJSONObject clone = new OrderedJSONObject(this);
+            final Iterator<String> thisOrder = this.keys();
+            clone.order.clear();
+            while (thisOrder.hasNext()) {
+                clone.order.add(thisOrder.next());
+            }
+            return clone;
+        } catch (JSONException jEx) {
+            throw new RuntimeException(jEx);
         }
-        return clone;
-    }
-
-    /**
-     * Method to obtain the order in which the items will be serialized.
-     * @return An iterator that represents the attribute names in the order that they will be serialized.
-     */
-    public Iterator getOrder() {
-        return this.order.iterator();
     }
 }

--- a/src/main/java/org/apache/wink/json4j/compat/JSONArray.java
+++ b/src/main/java/org/apache/wink/json4j/compat/JSONArray.java
@@ -27,75 +27,75 @@ import java.util.Map;
  *
  */
 public interface JSONArray {
-	
-	// ------- data accessor methods -------
-	public Object get(int index) throws JSONException;
-	
-	public boolean getBoolean(int index) throws JSONException;
-	
-	public double getDouble(int index) throws JSONException;
-	
-	public int getInt(int index) throws JSONException;
-	
-	public long getLong(int index) throws JSONException;
 
-        public short getShort(int index) throws JSONException;
-	
-	public String getString(int index) throws JSONException;
-	
-	public JSONArray getJSONArray(int index) throws JSONException;
-	
-	public JSONObject getJSONObject(int index) throws JSONException;
-	
-	// ------- modifier methods -------	
-	
-	public String join(String separator);
-	
-	public JSONArray put(boolean value);
-	
-	public JSONArray put(Collection value) throws JSONException ;
-	
-	public JSONArray put(double value);
-	
-	public JSONArray put(int value);
-	
-	public JSONArray put(int index, boolean value) throws JSONException;
+    // ------- data accessor methods -------
+    Object get(int index) throws JSONException;
 
-	public JSONArray put(int index, Collection value) throws JSONException;
-	
-	public JSONArray put(int index, double value) throws JSONException;	
-	
-	public JSONArray put(int index, int value) throws JSONException;
-	
-	public JSONArray put(int index, long value) throws JSONException;
-        
-        public JSONArray put(int index, short value) throws JSONException;
-	
-	public JSONArray put(int index, Map value) throws JSONException;
-	
-	public JSONArray put(int index, Object value) throws JSONException;
-		
-	public JSONArray put(long value);
-        
-        public JSONArray put(short value);
-	
-	public JSONArray put(Map value) throws JSONException ;
-	
-	public JSONArray put(Object value) throws JSONException ;
-	
-	public Object remove(int index);
-	
-	// ------- utility methods -------	
-	
-	public boolean isNull(int index);
-	
-	public int length();
-	
-	// ------- output methods -------
-	
-	public String toString();
-	
-	public String toString(int indent);
-	
-	public Writer write(Writer w) throws JSONException;
+    boolean getBoolean(int index) throws JSONException;
+
+    double getDouble(int index) throws JSONException;
+
+    int getInt(int index) throws JSONException;
+
+    long getLong(int index) throws JSONException;
+
+    short getShort(int index) throws JSONException;
+
+    String getString(int index) throws JSONException;
+
+    JSONArray getJSONArray(int index) throws JSONException;
+
+    JSONObject getJSONObject(int index) throws JSONException;
+
+    // ------- modifier methods -------
+
+    String join(String separator);
+
+    JSONArray put(boolean value);
+
+    JSONArray put(Collection value) throws JSONException;
+
+    JSONArray put(double value);
+
+    JSONArray put(int value);
+
+    JSONArray put(int index, boolean value) throws JSONException;
+
+    JSONArray put(int index, Collection value) throws JSONException;
+
+    JSONArray put(int index, double value) throws JSONException;
+
+    JSONArray put(int index, int value) throws JSONException;
+
+    JSONArray put(int index, long value) throws JSONException;
+
+    JSONArray put(int index, short value) throws JSONException;
+
+    JSONArray put(int index, Map value) throws JSONException;
+
+    JSONArray put(int index, Object value) throws JSONException;
+
+    JSONArray put(long value);
+
+    JSONArray put(short value);
+
+    JSONArray put(Map value) throws JSONException;
+
+    JSONArray put(Object value) throws JSONException;
+
+    Object remove(int index);
+
+    // ------- utility methods -------
+
+    boolean isNull(int index);
+
+    int length();
+
+    // ------- output methods -------
+
+    String toString();
+
+    String toString(int indent);
+
+    Writer write(Writer w) throws JSONException;
 }

--- a/src/main/java/org/apache/wink/json4j/compat/impl/ApacheJSONArrayDelegate.java
+++ b/src/main/java/org/apache/wink/json4j/compat/impl/ApacheJSONArrayDelegate.java
@@ -384,7 +384,7 @@ public class ApacheJSONArrayDelegate implements JSONArray {
         try {
             return delegate.toString(indent);
         } catch (Exception ex) {
-            return "JSON Serializarion error: [" + ex.getMessage() + "]";
+            return "JSON Serialization error: [" + ex.getMessage() + "]";
         }
     }
 

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptions.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptions.java
@@ -49,6 +49,7 @@ public interface FormatOptions {
     }
 
     boolean emptyObjectsAndArrayClosuresOnSameLine();
+    boolean spaceBetweenKeyAndColon();
     boolean escapeForwardSlashes();
     String indentString();
     boolean isCompact();

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptions.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptions.java
@@ -22,17 +22,21 @@ package org.apache.wink.json4j.formatter;
 /**
  * This class allows configurability on the output formatting when the JSON
  * is written out to a string.
- *
+ * <p>
  * If <tt>Format.Compact</tt> is set, the only option used is <tt>#escapeForwardSlashes</tt>.
  * Otherwise, the serializer will use all the settings when determining how to format the
  * <tt>JSONObject</tt> or <tt>JSONArray</tt> to a string.
- *
- * The default value for newline is <tt>System.lineseparator()</tt><br/>
- * The default value for the indent is <tt>\t</tt><br/>
+ * </p>
+ * <p>
+ * The default value for newline is <tt>System.lineseparator()</tt>
+ * The default value for the indent is <tt>\t</tt>
+ * </p>
+ * <p>
  * The default value for empty array on same line is false, which will put the
  *   open/close brackets on different lines even if there are no values in the array
  * The default is to escape the forward slash character.  The JSON spec says this
  *   escaping is optional
+ * </p>
  *
  *   @see org.apache.wink.json4j.internal.Serializer
  *   @see org.apache.wink.json4j.internal.SerializerVerbose

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptions.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.formatter;
+
+/**
+ * This class allows configurability on the output formatting when the JSON
+ * is written out to a string.
+ *
+ * If <tt>Format.Compact</tt> is set, the only option used is <tt>#escapeForwardSlashes</tt>.
+ * Otherwise, the serializer will use all the settings when determining how to format the
+ * <tt>JSONObject</tt> or <tt>JSONArray</tt> to a string.
+ *
+ * The default value for newline is <tt>System.lineseparator()</tt><br/>
+ * The default value for the indent is <tt>\t</tt><br/>
+ * The default value for empty array on same line is false, which will put the
+ *   open/close brackets on different lines even if there are no values in the array
+ * The default is to escape the forward slash character.  The JSON spec says this
+ *   escaping is optional
+ *
+ *   @see org.apache.wink.json4j.internal.Serializer
+ *   @see org.apache.wink.json4j.internal.SerializerVerbose
+ */
+public interface FormatOptions {
+
+    enum Format {
+        Verbose,
+        Compact
+    }
+
+    boolean emptyObjectsAndArrayClosuresOnSameLine();
+    boolean escapeForwardSlashes();
+    String indentString();
+    boolean isCompact();
+    boolean isVerbose();
+    String newline();
+ }

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilder.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.formatter;
+
+/**
+ * Builder class for <tt>FormatOptions</tt> instances
+ */
+public interface FormatOptionsBuilder {
+    FormatOptions build();
+
+    FormatOptionsBuilder setFormat(FormatOptions.Format format);
+    FormatOptionsBuilder setEscapeForwardSlashes(boolean flag);
+    FormatOptionsBuilder setEmptyArrayOnSameLine(boolean flag);
+    FormatOptionsBuilder setNewlineString(String newline);
+    FormatOptionsBuilder setIndentString(String indent);
+
+    /**
+     * Returns a new instance of a <tt>FormatOptions</tt> object
+     * which uses all the defaults
+     * @return new instance with default formatting options
+     * @see FormatOptions
+     */
+    static FormatOptions basic() {
+        return new FormatOptionsBuilderImpl().build();
+    }
+}

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilder.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilder.java
@@ -26,8 +26,9 @@ public interface FormatOptionsBuilder {
     FormatOptions build();
 
     FormatOptionsBuilder setFormat(FormatOptions.Format format);
-    FormatOptionsBuilder setEscapeForwardSlashes(boolean flag);
     FormatOptionsBuilder setEmptyArrayOnSameLine(boolean flag);
+    FormatOptionsBuilder setEscapeForwardSlashes(boolean flag);
+    FormatOptionsBuilder setSpaceBetweenKeyAndColon(boolean flag);
     FormatOptionsBuilder setNewlineString(String newline);
     FormatOptionsBuilder setIndentString(String indent);
 

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderImpl.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderImpl.java
@@ -1,0 +1,41 @@
+package org.apache.wink.json4j.formatter;
+
+public class FormatOptionsBuilderImpl implements FormatOptionsBuilder {
+
+    private final FormatOptionsImpl formatOptions = new FormatOptionsImpl();
+
+    @Override
+    public FormatOptions build() {
+        return formatOptions;
+    }
+
+    @Override
+    public FormatOptionsBuilder setFormat(final FormatOptions.Format format) {
+        formatOptions.setFormat(format);
+        return this;
+    }
+
+    @Override
+    public FormatOptionsBuilder setEscapeForwardSlashes(final boolean flag) {
+        formatOptions.setEscapeForwardSlashes(flag);
+        return this;
+    }
+
+    @Override
+    public FormatOptionsBuilder setEmptyArrayOnSameLine(final boolean flag) {
+        formatOptions.setEmptyObjectsAndArrayClosuresOnSameLine(flag);
+        return this;
+    }
+
+    @Override
+    public FormatOptionsBuilder setNewlineString(final String newline) {
+        formatOptions.setNewline(newline);
+        return this;
+    }
+
+    @Override
+    public FormatOptionsBuilder setIndentString(final String indent) {
+        formatOptions.setIndentString(indent);
+        return this;
+    }
+}

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderImpl.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderImpl.java
@@ -16,14 +16,20 @@ public class FormatOptionsBuilderImpl implements FormatOptionsBuilder {
     }
 
     @Override
+    public FormatOptionsBuilder setEmptyArrayOnSameLine(final boolean flag) {
+        formatOptions.setEmptyObjectsAndArrayClosuresOnSameLine(flag);
+        return this;
+    }
+
+    @Override
     public FormatOptionsBuilder setEscapeForwardSlashes(final boolean flag) {
         formatOptions.setEscapeForwardSlashes(flag);
         return this;
     }
 
     @Override
-    public FormatOptionsBuilder setEmptyArrayOnSameLine(final boolean flag) {
-        formatOptions.setEmptyObjectsAndArrayClosuresOnSameLine(flag);
+    public FormatOptionsBuilder setSpaceBetweenKeyAndColon(final boolean flag) {
+        formatOptions.setSpaceBetweenKeyAndColon(flag);
         return this;
     }
 

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsImpl.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsImpl.java
@@ -22,8 +22,9 @@ package org.apache.wink.json4j.formatter;
 class FormatOptionsImpl implements FormatOptions {
 
     private Format format = Format.Compact;
-    private boolean escapeForwardSlashes = true;
     private boolean emptyObjectsAndArrayClosuresOnSameLine = false;
+    private boolean escapeForwardSlashes = true;
+    private boolean spaceBetweenKeyAndColon = false;
     private String newlineStr = System.lineSeparator();
     private String indentStr = "\t";
 
@@ -44,6 +45,16 @@ class FormatOptionsImpl implements FormatOptions {
 
     public FormatOptionsImpl setEscapeForwardSlashes(boolean flag) {
         escapeForwardSlashes = flag;
+        return this;
+    }
+
+    @Override
+    public boolean spaceBetweenKeyAndColon() {
+        return spaceBetweenKeyAndColon;
+    }
+
+    public FormatOptionsImpl setSpaceBetweenKeyAndColon(boolean flag) {
+        spaceBetweenKeyAndColon = flag;
         return this;
     }
 

--- a/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsImpl.java
+++ b/src/main/java/org/apache/wink/json4j/formatter/FormatOptionsImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.formatter;
+
+class FormatOptionsImpl implements FormatOptions {
+
+    private Format format = Format.Compact;
+    private boolean escapeForwardSlashes = true;
+    private boolean emptyObjectsAndArrayClosuresOnSameLine = false;
+    private String newlineStr = System.lineSeparator();
+    private String indentStr = "\t";
+
+    @Override
+    public boolean emptyObjectsAndArrayClosuresOnSameLine() {
+        return emptyObjectsAndArrayClosuresOnSameLine;
+    }
+
+    public FormatOptionsImpl setEmptyObjectsAndArrayClosuresOnSameLine(boolean flag) {
+        emptyObjectsAndArrayClosuresOnSameLine = flag;
+        return this;
+    }
+
+    @Override
+    public boolean escapeForwardSlashes() {
+        return escapeForwardSlashes;
+    }
+
+    public FormatOptionsImpl setEscapeForwardSlashes(boolean flag) {
+        escapeForwardSlashes = flag;
+        return this;
+    }
+
+    @Override
+    public String indentString() {
+        return indentStr;
+    }
+
+    public FormatOptionsImpl setIndentString(String str) {
+        if (null == str) {
+            throw new IllegalArgumentException("indent string cannot be null");
+        }
+        indentStr = str;
+        return this;
+    }
+
+    @Override
+    public boolean isCompact() {
+        return Format.Compact == format;
+    }
+
+    @Override
+    public boolean isVerbose() {
+        return Format.Verbose == format;
+    }
+
+    @Override
+    public String newline() {
+        return newlineStr;
+    }
+
+    public FormatOptionsImpl setNewline(String newline) {
+        if (null == newline) {
+            throw new IllegalArgumentException("newline string cannot be null");
+        }
+        newlineStr = newline;
+        return this;
+    }
+
+    public FormatOptionsImpl setFormat(Format newFormat) {
+        format = newFormat;
+        return this;
+    }
+}

--- a/src/main/java/org/apache/wink/json4j/internal/Serializer.java
+++ b/src/main/java/org/apache/wink/json4j/internal/Serializer.java
@@ -297,6 +297,7 @@ public class Serializer {
                     newLine();
                     indent();
                     writeString(key);
+                    if (formatOptions.spaceBetweenKeyAndColon()) { space(); }
                     writeRawString(":");
                     space();
                     write(value);

--- a/src/main/java/org/apache/wink/json4j/internal/Serializer.java
+++ b/src/main/java/org/apache/wink/json4j/internal/Serializer.java
@@ -19,39 +19,79 @@
 
 package org.apache.wink.json4j.internal;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.wink.json4j.JSONArray;
+import org.apache.wink.json4j.JSONException;
 import org.apache.wink.json4j.JSONObject;
 import org.apache.wink.json4j.JSONString;
-import org.apache.wink.json4j.OrderedJSONObject;
+import org.apache.wink.json4j.formatter.FormatOptions;
+import org.apache.wink.json4j.formatter.FormatOptionsBuilder;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Iterator;
 
 /**
  * Class to handle serialization of a JSON object to a JSON string.
  */
 public class Serializer {
 
+    private static final String OPEN_BRACE = "{";
+    private static final String CLOSE_BRACE = "}";
+    private static final String OPEN_BRACKET = "[";
+    private static final String CLOSE_BRACKET = "]";
+    private FormatOptions formatOptions;
+
     /**
      * The writer to use when writing this JSON object.
      */
-    private Writer writer;
+    private final Writer writer;
 
     /**
      * Create a serializer on the specified output stream writer.
+     *
+     * @param writer destination
      */
     public Serializer(Writer writer) {
         super();
-
         this.writer = writer;
+        this.formatOptions = FormatOptionsBuilder.basic();
+    }
+
+    /**
+     * Create a seraializers on the specified output stream writer with
+     * the passed format options
+     *
+     * @param writer        destination
+     * @param formatOptions format options
+     */
+    public Serializer(Writer writer, FormatOptions formatOptions) {
+        super();
+        this.writer = writer;
+        this.formatOptions = formatOptions;
+    }
+
+    /**
+     * This is only here because we needed to support the old constructors for
+     * SerializerVerbose and we couldn't construct the FormatOptions and call
+     * suuper() or this(writer, formatoptions).
+     *
+     * @param fo format options
+     */
+    protected void setFormatOptions(FormatOptions fo) {
+        this.formatOptions = fo;
+    }
+
+    /**
+     * Gets the currently configured <tt>FormatOptions</tt>
+     * @return - format options
+     */
+    protected FormatOptions formatOptions() {
+        return formatOptions;
     }
 
     /**
      * Method to flush the current writer.
+     *
      * @throws IOException Thrown if an error occurs during writer flush.
      */
     public void flush() throws IOException {
@@ -60,6 +100,7 @@ public class Serializer {
 
     /**
      * Method to close the current writer.
+     *
      * @throws IOException Thrown if an error occurs during writer close.
      */
     public void close() throws IOException {
@@ -68,6 +109,7 @@ public class Serializer {
 
     /**
      * Method to write a raw string to the writer.
+     *
      * @param s The String to write.
      * @throws IOException Thrown if an error occurs during write.
      */
@@ -79,6 +121,7 @@ public class Serializer {
 
     /**
      * Method to write the text string 'null' to the output stream (null JSON object).
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
     public Serializer writeNull() throws IOException {
@@ -88,6 +131,7 @@ public class Serializer {
 
     /**
      * Method to write a number to the current writer.
+     *
      * @param value The Boolean object to write out as a JSON boolean.
      * @return Serializer
      * @throws IOException Thrown if an error occurs during write.
@@ -96,13 +140,13 @@ public class Serializer {
         if (null == value) return writeNull();
 
         if (value instanceof Float) {
-            if (((Float)value).isNaN()) return writeNull();
+            if (((Float) value).isNaN()) return writeNull();
             if (Float.NEGATIVE_INFINITY == value.floatValue()) return writeNull();
             if (Float.POSITIVE_INFINITY == value.floatValue()) return writeNull();
         }
 
         if (value instanceof Double) {
-            if (((Double)value).isNaN()) return writeNull();
+            if (((Double) value).isNaN()) return writeNull();
             if (Double.NEGATIVE_INFINITY == value.doubleValue()) return writeNull();
             if (Double.POSITIVE_INFINITY == value.doubleValue()) return writeNull();
         }
@@ -114,6 +158,7 @@ public class Serializer {
 
     /**
      * Method to write a boolean value to the output stream.
+     *
      * @param value The Boolean object to write out as a JSON boolean.
      * @throws IOException Thrown if an error occurs during write.
      */
@@ -127,14 +172,15 @@ public class Serializer {
 
     /**
      * Method to generate a string with a particular width.  Alignment is done using zeroes if it does not meet the width requirements.
-     * @param s The string to write
+     *
+     * @param s   The string to write
      * @param len The minimum length it should be, and to align with zeroes if length is smaller.
      * @return A string properly aligned/correct width.
      */
     private String rightAlignedZero(String s, int len) {
         if (len == s.length()) return s;
 
-        StringBuffer sb = new StringBuffer(s);
+        StringBuilder sb = new StringBuilder(s);
 
         while (sb.length() < len) {
             sb.insert(0, '0');
@@ -145,6 +191,7 @@ public class Serializer {
 
     /**
      * Method to write a String out to the writer, encoding special characters and unicode characters properly.
+     *
      * @param value The string to write out.
      * @throws IOException Thrown if an error occurs during write.
      */
@@ -155,24 +202,46 @@ public class Serializer {
 
         char[] chars = value.toCharArray();
 
-        for (int i=0; i<chars.length; i++) {
+        for (int i = 0; i < chars.length; i++) {
             char c = chars[i];
             switch (c) {
-                case  '"': writer.write("\\\""); break;
-                case '\\': writer.write("\\\\"); break;
-                case    0: writer.write("\\0"); break;
-                case '\b': writer.write("\\b"); break;
-                case '\t': writer.write("\\t"); break;
-                case '\n': writer.write("\\n"); break;
-                case '\f': writer.write("\\f"); break;
-                case '\r': writer.write("\\r"); break;
-                case '/': writer.write("\\/"); break;
+                case '"':
+                    writer.write("\\\"");
+                    break;
+                case '\\':
+                    writer.write("\\\\");
+                    break;
+                case 0:
+                    writer.write("\\0");
+                    break;
+                case '\b':
+                    writer.write("\\b");
+                    break;
+                case '\t':
+                    writer.write("\\t");
+                    break;
+                case '\n':
+                    writer.write("\\n");
+                    break;
+                case '\f':
+                    writer.write("\\f");
+                    break;
+                case '\r':
+                    writer.write("\\r");
+                    break;
+                case '/':
+                    if (formatOptions.escapeForwardSlashes()) {
+                        writer.write("\\/");
+                    } else {
+                        writer.write(c);
+                    }
+                    break;
                 default:
                     if ((c >= 32) && (c <= 126)) {
                         writer.write(c);
                     } else {
                         writer.write("\\u");
-                        writer.write(rightAlignedZero(Integer.toHexString(c),4));
+                        writer.write(rightAlignedZero(Integer.toHexString(c), 4));
                     }
             }
         }
@@ -184,12 +253,14 @@ public class Serializer {
 
     /**
      * Method to write out a generic JSON type.
+     *
      * @param object The JSON compatible object to serialize.
+     * @return <tt>Serializer</tt> <pre>this</pre> object
      * @throws IOException Thrown if an error occurs during write, or if a nonJSON compatible Java object is passed..
      */
     private Serializer write(Object object) throws IOException {
         if (null == object) return writeNull();
-        
+
         // Serialize the various types!
         Class clazz = object.getClass();
         if (Number.class.isAssignableFrom(clazz)) return writeNumber((Number) object);
@@ -204,6 +275,7 @@ public class Serializer {
 
     /**
      * Method to write a complete JSON object to the stream.
+     *
      * @param object The JSON object to write out.
      * @throws IOException Thrown if an error occurs during write.
      */
@@ -211,45 +283,45 @@ public class Serializer {
         if (null == object) return writeNull();
 
         // write header
-        writeRawString("{");
-        indentPush();
+        writeRawString(OPEN_BRACE);
 
-        Iterator iter = null;
-        if (object instanceof OrderedJSONObject) {
-            iter = ((OrderedJSONObject)object).getOrder();
-        } else {
-            List propertyNames = getPropertyNames(object);
-            iter = propertyNames.iterator();
-        }
+        if (!formatOptions.emptyObjectsAndArrayClosuresOnSameLine() || !object.isEmpty()) {
 
-        while ( iter.hasNext() ) {
-            Object key = iter.next();
-            if (!(key instanceof String)) throw new IOException("attempting to serialize object with an invalid property name: '" + key + "'" );
+            indentPush();
 
-            Object value = object.get(key);
-            if (!JSONObject.isValidObject(value)) throw new IOException("attempting to serialize object with an invalid property value: '" + value + "'");
+            for (Iterator<String> iter = object.orderedKeys(); iter.hasNext(); ) {
+                String key = iter.next();
+                try {
+                    Object value = object.get(key);
+                    if (!JSONObject.isValidObject(value)) {
+                        throw new IOException("attempting to serialize object with an invalid property value: '" + value + "'");
+                    }
+                    newLine();
+                    indent();
+                    writeString(key);
+                    writeRawString(":");
+                    space();
+                    write(value);
+                } catch (JSONException jEx) {
+                    throw new IOException(jEx);
+                }
 
+                if (iter.hasNext()) writeRawString(",");
+            }
+
+            // write trailer
+            indentPop();
             newLine();
             indent();
-            writeString((String)key);
-            writeRawString(":");
-            space();
-            write(value);
-
-            if (iter.hasNext()) writeRawString(",");
         }
-
-        // write trailer
-        indentPop();
-        newLine();
-        indent();
-        writeRawString("}");
+        writeRawString(CLOSE_BRACE);
 
         return this;
     }
 
     /**
      * Method to write a JSON array out to the stream.
+     *
      * @param value The JSON array to write out.
      * @throws IOException Thrown if an error occurs during write.
      */
@@ -257,25 +329,29 @@ public class Serializer {
         if (null == value) return writeNull();
 
         // write header
-        writeRawString("[");
-        indentPush();
+        writeRawString(OPEN_BRACKET);
+        if (!formatOptions.emptyObjectsAndArrayClosuresOnSameLine() || !value.isEmpty()) {
 
-        for (Iterator iter=value.iterator(); iter.hasNext(); ) {
-            Object element = iter.next();
-            if (!JSONObject.isValidObject(element)) throw new IOException("attempting to serialize array with an invalid element: '" + value + "'");
+            indentPush();
 
+            for (Iterator iter = value.iterator(); iter.hasNext(); ) {
+                Object element = iter.next();
+                if (!JSONObject.isValidObject(element))
+                    throw new IOException("attempting to serialize array with an invalid element: '" + value + "'");
+
+                newLine();
+                indent();
+                write(element);
+
+                if (iter.hasNext()) writeRawString(",");
+            }
+
+            // write trailer
+            indentPop();
             newLine();
             indent();
-            write(element);
-
-            if (iter.hasNext()) writeRawString(",");
         }
-
-        // write trailer
-        indentPop();
-        newLine();
-        indent();
-        writeRawString("]");
+        writeRawString(CLOSE_BRACKET);
 
         return this;
     }
@@ -286,6 +362,7 @@ public class Serializer {
 
     /**
      * Method to write a space to the output writer.
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
     public void space() throws IOException {
@@ -293,6 +370,7 @@ public class Serializer {
 
     /**
      * Method to write a newline to the output writer.
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
     public void newLine() throws IOException {
@@ -300,6 +378,7 @@ public class Serializer {
 
     /**
      * Method to write an indent to the output writer.
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
     public void indent() throws IOException {
@@ -316,13 +395,4 @@ public class Serializer {
      */
     public void indentPop() {
     }
-
-    /**
-     * Method to get a list of all the property names stored in a map.
-     * @param map source map
-     */
-    public List getPropertyNames(Map map) {
-        return new ArrayList(map.keySet());
-    }
-
 }

--- a/src/main/java/org/apache/wink/json4j/internal/Serializer.java
+++ b/src/main/java/org/apache/wink/json4j/internal/Serializer.java
@@ -19,10 +19,7 @@
 
 package org.apache.wink.json4j.internal;
 
-import org.apache.wink.json4j.JSONArray;
-import org.apache.wink.json4j.JSONException;
-import org.apache.wink.json4j.JSONObject;
-import org.apache.wink.json4j.JSONString;
+import org.apache.wink.json4j.*;
 import org.apache.wink.json4j.formatter.FormatOptions;
 import org.apache.wink.json4j.formatter.FormatOptionsBuilder;
 
@@ -83,6 +80,7 @@ public class Serializer {
 
     /**
      * Gets the currently configured <tt>FormatOptions</tt>
+     *
      * @return - format options
      */
     protected FormatOptions formatOptions() {
@@ -263,12 +261,12 @@ public class Serializer {
 
         // Serialize the various types!
         Class clazz = object.getClass();
+        if (String.class.isAssignableFrom(clazz)) return writeString((String) object);
+        if (JSONObject.class.isAssignableFrom(clazz)) return writeObject((JSONObject) object);
         if (Number.class.isAssignableFrom(clazz)) return writeNumber((Number) object);
         if (Boolean.class.isAssignableFrom(clazz)) return writeBoolean((Boolean) object);
-        if (JSONObject.class.isAssignableFrom(clazz)) return writeObject((JSONObject) object);
         if (JSONArray.class.isAssignableFrom(clazz)) return writeArray((JSONArray) object);
         if (JSONString.class.isAssignableFrom(clazz)) return writeRawString(((JSONString) object).toJSONString());
-        if (String.class.isAssignableFrom(clazz)) return writeString((String) object);
 
         throw new IOException("Attempting to serialize unserializable object: '" + object + "'");
     }

--- a/src/main/java/org/apache/wink/json4j/internal/SerializerVerbose.java
+++ b/src/main/java/org/apache/wink/json4j/internal/SerializerVerbose.java
@@ -19,6 +19,9 @@
 
 package org.apache.wink.json4j.internal;
 
+import org.apache.wink.json4j.formatter.FormatOptions;
+import org.apache.wink.json4j.formatter.FormatOptionsBuilderImpl;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collections;
@@ -36,90 +39,103 @@ public class SerializerVerbose extends Serializer {
      */
     private int indent = 0;
 
-    /**
-     * The indent string to use when serializing.
-     */
-    private String indentStr = "\t";
-
-    static final private String eol;
-
-    static {
-        eol = System.lineSeparator();
+    private SerializerVerbose() {
+        super(null);
     }
 
     /**
-     * Constructor.
+     * Constructor
+     *
+     * @param writer The writer to serialize JSON to.
      */
     public SerializerVerbose(Writer writer) {
-        super(writer);
+        super(writer, new FormatOptionsBuilderImpl().setFormat(FormatOptions.Format.Verbose).build());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param writer        The writer to serialize JSON to.
+     * @param formatOptions format options to use.
+     */
+    public SerializerVerbose(Writer writer, FormatOptions formatOptions) {
+        super(writer, formatOptions);
     }
 
     /**
      * Constructor.
-     * @param writer The writer to serialize JSON to.
-     * @param indentSpaces How many spaces to indent by (0 to 8).
-     * The default indent is the TAB character. 
+     *
+     * @param writer       The writer to serialize JSON to.
+     * @param indentSpaces How many spaces to indent by.
+     *                     The default indent is the TAB (<tt>\t</tt>) character.
      */
     public SerializerVerbose(Writer writer, int indentSpaces) {
         super(writer);
-        if(indentSpaces > 0 && indentSpaces < 8){
-            this.indentStr = "";
-            for(int i = 0; i < indentSpaces; i++){
-                this.indentStr += " ";
-            }
+        if (indentSpaces < 0) {
+            throw new IllegalArgumentException();
         }
+
+        StringBuilder sb = new StringBuilder("");
+        for (int i = 0; i < indentSpaces; i++) {
+            sb.append(" ");
+        }
+
+        setFormatOptions(new FormatOptionsBuilderImpl()
+                .setFormat(FormatOptions.Format.Verbose)
+                .setIndentString(sb.toString())
+                .build());
     }
 
     /**
      * Method to write a space to the output writer.
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
+    @Override
     public void space() throws IOException {
         writeRawString(" ");
     }
 
     /**
      * Method to write a newline to the output writer.
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
+    @Override
     public void newLine() throws IOException {
-        writeRawString(eol);
+        writeRawString(formatOptions().newline());
     }
 
     /**
      * Method to write an indent to the output writer.
+     *
      * @throws IOException Thrown if an error occurs during write.
      */
+    @Override
     public void indent() throws IOException {
-        for (int i=0; i<indent; i++) writeRawString(this.indentStr);
+        for (int i = 0; i < indent; i++) {
+            writeRawString(formatOptions().indentString());
+        }
     }
 
     /**
      * Method to increase the indent depth of the output writer.
      */
+    @Override
     public void indentPush() {
         indent++;
     }
 
     /**
      * Method to reduce the indent depth of the output writer.
+     *
      * @throws IllegalStateException if the ident tries to pop below 0
      */
+    @Override
     public void indentPop() {
         indent--;
-        if (indent < 0) throw new IllegalStateException();
+        if (indent < 0) {
+            throw new IllegalStateException();
+        }
     }
-
-    /**
-     * Method to get a sorted list of all the property names stored in a map.
-     * @param map
-     */
-    public List getPropertyNames(Map map) {
-        List propertyNames = super.getPropertyNames(map);
-
-        Collections.sort(propertyNames);
-
-        return propertyNames;
-    }
-
 }

--- a/src/main/java/org/apache/wink/json4j/internal/Tokenizer.java
+++ b/src/main/java/org/apache/wink/json4j/internal/Tokenizer.java
@@ -546,7 +546,7 @@ public class Tokenizer {
     /**
      * Method to read the next character from the string, keeping track of line/column position.
      * 
-     * @throws IOEXception Thrown when underlying reader throws an error.
+     * @throws IOException Thrown when underlying reader throws an error.
      */
     private void readChar() throws IOException {
         if ('\n' == lastChar) {

--- a/src/main/java/org/apache/wink/json4j/internal/Tokenizer.java
+++ b/src/main/java/org/apache/wink/json4j/internal/Tokenizer.java
@@ -19,37 +19,33 @@
 
 package org.apache.wink.json4j.internal;
 
-import java.io.BufferedReader;
-import java.io.CharArrayReader;
-import java.io.IOException;
-import java.io.PushbackReader;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.*;
 
 /**
  * Tokenizes a stream into JSON tokens.
  */
 public class Tokenizer {
 
+    public static final String NON_HEX_DIGIT = "non-hex digit ";
     /**
      * The reader from which the JSON string is being read.
      */
     private Reader reader;
 
-    /** 
+    /**
      * The current line position in the JSON string.
      */
-    private int     lineNo;
+    private int lineNo;
 
     /**
      * The current column position in the JSON string.
      */
-    private int     colNo;
+    private int colNo;
 
-    /** 
+    /**
      * The last character read from the JSON string.
      */
-    private int     lastChar;
+    private int lastChar;
 
     /**
      * Whether or not the parser should be spec strict, or allow unquoted strings and comments
@@ -58,83 +54,98 @@ public class Tokenizer {
 
     /**
      * Constructor.
+     *
      * @param reader The reader from which the JSON string is read.  Same as Tokenizer(reader, false);
-     * 
      * @throws IOException Thrown on IOErrors such as invalid JSON or sudden reader closures.
      */
-    public Tokenizer(Reader reader) throws IOException {
+    public Tokenizer(final Reader reader) throws IOException {
         super();
 
-        Class readerClass= reader.getClass();
+        Class readerClass = reader.getClass();
         //In-memory readers don't need to be buffered.  Also, skip PushbackReaders
         //because they probably already wrap a buffered stream.  And lastly, anything
         //that extends from a BufferedReader also doesn't need buffering!
-        if (!StringReader.class.isAssignableFrom(readerClass) && 
-            !CharArrayReader.class.isAssignableFrom(readerClass) &&
-            !PushbackReader.class.isAssignableFrom(readerClass) &&
-            !BufferedReader.class.isAssignableFrom(readerClass)) {
-            reader = new BufferedReader(reader);
+        if (!StringReader.class.isAssignableFrom(readerClass) &&
+                !CharArrayReader.class.isAssignableFrom(readerClass) &&
+                !PushbackReader.class.isAssignableFrom(readerClass) &&
+                !BufferedReader.class.isAssignableFrom(readerClass)) {
+            this.reader = new BufferedReader(reader);
+        } else {
+            this.reader = reader;
         }
-        this.reader    = reader;
-        this.lineNo    = 0;
-        this.colNo     = 0;
-        this.lastChar  = '\n';
+        this.lineNo = 0;
+        this.colNo = 0;
+        this.lastChar = '\n';
         readChar();
     }
 
     /**
      * Constructor.
+     *
      * @param reader The reader from which the JSON string is read.
      * @param strict Whether or not the parser should be spec strict, or allow unquoted strings and comments.
-     * 
      * @throws IOException Thrown on IOErrors such as invalid JSON or sudden reader closures.
      */
-    public Tokenizer(Reader reader, boolean strict) throws IOException {
+    public Tokenizer(final Reader reader, boolean strict) throws IOException {
         super();
 
-        Class readerClass= reader.getClass();
+        Class readerClass = reader.getClass();
         //In-memory readers don't need to be buffered.  Also, skip PushbackReaders
         //because they probably already wrap a buffered stream.  And lastly, anything
         //that extends from a BufferedReader also doesn't need buffering!
-        if (!StringReader.class.isAssignableFrom(readerClass) && 
-            !CharArrayReader.class.isAssignableFrom(readerClass) &&
-            !PushbackReader.class.isAssignableFrom(readerClass) &&
-            !BufferedReader.class.isAssignableFrom(readerClass)) {
-            reader = new BufferedReader(reader);
+        if (!StringReader.class.isAssignableFrom(readerClass) &&
+                !CharArrayReader.class.isAssignableFrom(readerClass) &&
+                !PushbackReader.class.isAssignableFrom(readerClass) &&
+                !BufferedReader.class.isAssignableFrom(readerClass)) {
+            this.reader = new BufferedReader(reader);
+        } else {
+            this.reader = reader;
         }
-        this.reader    = reader;
-        this.lineNo    = 0;
-        this.colNo     = 0;
-        this.lastChar  = '\n';
-        this.strict    = strict;
+        this.lineNo = 0;
+        this.colNo = 0;
+        this.lastChar = '\n';
+        this.strict = strict;
 
         readChar();
     }
 
     /**
      * Method to get the next JSON token from the JSON String
-     * @return The next token in the stream, returning Token.TokenEOF when finished.
      *
+     * @return The next token in the stream, returning Token.TokenEOF when finished.
      * @throws IOException Thrown if unexpected read error occurs or invalid character encountered in JSON string.
      */
     public Token next() throws IOException {
 
         // skip whitespace, use our own checker, it seems
         // a bit faster than Java's default.
-        //while (Character.isWhitespace((char)lastChar)) {
-        while (isWhitespace((char)lastChar)) {
+        while (isWhitespace((char) lastChar)) {
             readChar();
         }
 
         // handle punctuation
         switch (lastChar) {
-            case -1:  readChar(); return Token.TokenEOF;
-            case '{': readChar(); return Token.TokenBraceL;
-            case '}': readChar(); return Token.TokenBraceR;
-            case '[': readChar(); return Token.TokenBrackL;
-            case ']': readChar(); return Token.TokenBrackR;
-            case ':': readChar(); return Token.TokenColon;
-            case ',': readChar(); return Token.TokenComma;
+            case -1:
+                readChar();
+                return Token.TokenEOF;
+            case '{':
+                readChar();
+                return Token.TokenBraceL;
+            case '}':
+                readChar();
+                return Token.TokenBraceR;
+            case '[':
+                readChar();
+                return Token.TokenBrackL;
+            case ']':
+                readChar();
+                return Token.TokenBrackR;
+            case ':':
+                readChar();
+                return Token.TokenColon;
+            case ',':
+                readChar();
+                return Token.TokenComma;
 
             case '"':
             case '\'':
@@ -156,14 +167,20 @@ public class Tokenizer {
                 Number numberValue = readNumber();
                 return new Token(numberValue);
 
-            case 'n': 
+            case 'n':
             case 't':
             case 'f':
                 String ident = readIdentifier();
 
-                if (ident.equals("null"))  return Token.TokenNull;
-                if (ident.equals("true"))  return Token.TokenTrue;
-                if (ident.equals("false")) return Token.TokenFalse;
+                if (ident.equals("null")) {
+                    return Token.TokenNull;
+                }
+                if (ident.equals("true")) {
+                    return Token.TokenTrue;
+                }
+                if (ident.equals("false")) {
+                    return Token.TokenFalse;
+                }
 
                 // Okay, this was some sort of unquoted string, may be okay
                 if (!this.strict) {
@@ -183,16 +200,16 @@ public class Tokenizer {
                 }
 
             default:
-                if (!this.strict && isValidUnquotedChar((char)lastChar)) {
+                if (!this.strict && isValidUnquotedChar((char) lastChar)) {
                     // Unquoted string.  Bad form, but ... okay, lets accept it.
                     // some other parsers do.
                     String unquotedStr = readIdentifier();
                     return new Token(unquotedStr);
                 } else {
                     if (this.strict) {
-                        throw new IOException("Unexpected character '" + (char)lastChar + "' " + onLineCol() + ".  Unquoted strings are not allowed in strict mode.");
+                        throw new IOException("Unexpected character '" + (char) lastChar + "' " + onLineCol() + ".  Unquoted strings are not allowed in strict mode.");
                     } else {
-                        throw new IOException("Unexpected character '" + (char)lastChar + "' " + onLineCol());
+                        throw new IOException("Unexpected character '" + (char) lastChar + "' " + onLineCol());
                     }
                 }
         }
@@ -206,23 +223,23 @@ public class Tokenizer {
      */
     private void readComment() throws IOException {
         readChar();
-        if ((char)lastChar == '/') {
+        if ((char) lastChar == '/') {
             // Okay, // comment,so just read to \n or end of line
-            while ((char)lastChar != '\n' && lastChar != -1) {
+            while ((char) lastChar != '\n' && lastChar != -1) {
                 readChar();
             }
-        } else if ((char)lastChar == '*') {
+        } else if ((char) lastChar == '*') {
             // /* comment, so read past it.
             char[] chars = new char[2];
             readChar();
             if (lastChar != -1) {
-                chars[0] = (char)lastChar;
+                chars[0] = (char) lastChar;
             } else {
                 return;
             }
             readChar();
             if (lastChar != -1) {
-                chars[1] = (char)lastChar;
+                chars[1] = (char) lastChar;
             } else {
                 return;
             }
@@ -231,8 +248,8 @@ public class Tokenizer {
                 readChar();
                 if (lastChar != -1) {
                     chars[0] = chars[1];
-                    chars[1] = (char)lastChar;
-                 
+                    chars[1] = (char) lastChar;
+
                 } else {
                     return;
                 }
@@ -242,22 +259,21 @@ public class Tokenizer {
 
     /**
      * Method to read a string from the JSON string, converting escapes accordingly.
-     * @return The parsed JSON string with all escapes properly converyed.
      *
+     * @return The parsed JSON string with all escapes properly converyed.
      * @throws IOException Thrown on unterminated strings, invalid characters, bad escapes, and so on.  Basically, invalid JSON.
      */
     private String readString() throws IOException {
-        StringBuffer sb    = new StringBuffer();
-        int          delim = lastChar;
-        int          l = lineNo;
-        int          c = colNo;
+        StringBuilder sb = new StringBuilder();
+        int delim = lastChar;
+        int l = lineNo;
+        int c = colNo;
 
         readChar();
         while ((-1 != lastChar) && (delim != lastChar)) {
-            StringBuffer digitBuffer;
 
             if (lastChar != '\\') {
-                sb.append((char)lastChar);
+                sb.append((char) lastChar);
                 readChar();
                 continue;
             }
@@ -265,28 +281,55 @@ public class Tokenizer {
             readChar();
 
             switch (lastChar) {
-                case 'b':  readChar(); sb.append('\b'); continue; 
-                case 'f':  readChar(); sb.append('\f'); continue; 
-                case 'n':  readChar(); sb.append('\n'); continue; 
-                case 'r':  readChar(); sb.append('\r'); continue; 
-                case 't':  readChar(); sb.append('\t'); continue; 
-                case '\'': readChar(); sb.append('\''); continue; 
-                case '"':  readChar(); sb.append('"');  continue; 
-                case '\\': readChar(); sb.append('\\'); continue;
-                case '/': readChar();  sb.append('/'); continue;
+                case 'b':
+                    readChar();
+                    sb.append('\b');
+                    continue;
+                case 'f':
+                    readChar();
+                    sb.append('\f');
+                    continue;
+                case 'n':
+                    readChar();
+                    sb.append('\n');
+                    continue;
+                case 'r':
+                    readChar();
+                    sb.append('\r');
+                    continue;
+                case 't':
+                    readChar();
+                    sb.append('\t');
+                    continue;
+                case '\'':
+                    readChar();
+                    sb.append('\'');
+                    continue;
+                case '"':
+                    readChar();
+                    sb.append('"');
+                    continue;
+                case '\\':
+                    readChar();
+                    sb.append('\\');
+                    continue;
+                case '/':
+                    readChar();
+                    sb.append('/');
+                    continue;
 
                     // hex constant
                     // unicode constant
                 case 'x':
                 case 'u':
-                    digitBuffer = new StringBuffer();
+                    final StringBuilder digitBuffer = new StringBuilder();
 
                     int toRead = 2;
                     if (lastChar == 'u') toRead = 4;
 
-                    for (int i=0; i<toRead; i++) {
+                    for (int i = 0; i < toRead; i++) {
                         readChar();
-                        if (!isHexDigit(lastChar)) throw new IOException("non-hex digit " + onLineCol());
+                        if (!isHexDigit(lastChar)) throw new IOException(NON_HEX_DIGIT + onLineCol());
                         digitBuffer.append((char) lastChar);
                     }
                     readChar();
@@ -295,36 +338,36 @@ public class Tokenizer {
                         int digitValue = Integer.parseInt(digitBuffer.toString(), 16);
                         sb.append((char) digitValue);
                     } catch (NumberFormatException e) {
-                        throw new IOException("non-hex digit " + onLineCol());
+                        throw new IOException(NON_HEX_DIGIT + onLineCol());
                     }
 
                     break;
 
-                    // octal constant
+                // octal constant
                 default:
-                    if (!isOctalDigit(lastChar)) throw new IOException("non-hex digit " + onLineCol());
+                    if (!isOctalDigit(lastChar)) throw new IOException(NON_HEX_DIGIT + onLineCol());
 
-                    digitBuffer = new StringBuffer();
-                    digitBuffer.append((char) lastChar);
+                    final StringBuilder octalBuffer = new StringBuilder();
+                    octalBuffer.append((char) lastChar);
 
-                    for (int i=0; i<2; i++) {
+                    for (int i = 0; i < 2; i++) {
                         readChar();
                         if (!isOctalDigit(lastChar)) break;
 
-                        digitBuffer.append((char) lastChar);
+                        octalBuffer.append((char) lastChar);
                     }
 
                     try {
-                        int digitValue = Integer.parseInt(digitBuffer.toString(), 8);
-                        sb.append((char) digitValue);
+                        final int octalValue = Integer.parseInt(octalBuffer.toString(), 8);
+                        sb.append((char) octalValue);
                     } catch (NumberFormatException e) {
-                        throw new IOException("non-hex digit " + onLineCol());
+                        throw new IOException(NON_HEX_DIGIT + onLineCol());
                     }
             }
         }
 
         if (-1 == lastChar) {
-            throw new IOException("String not terminated " + onLineCol(l,c));
+            throw new IOException("String not terminated " + onLineCol(l, c));
         }
 
         readChar();
@@ -334,49 +377,47 @@ public class Tokenizer {
 
     /**
      * Method to read a number from the JSON string.
-     * 
+     * <p>
      * (-)(1-9)(0-9)*            : decimal
      * (-)0(0-7)*               : octal
      * (-)0(x|X)(0-9|a-f|A-F)*  : hex
-     * [digits][.digits][(E|e)[(+|-)]digits]         
+     * [digits][.digits][(E|e)[(+|-)]digits]
      *
-     * @returns The number as the wrapper Java Number type.
-     * 
+     * @return The number as the wrapper Java Number type.
      * @throws IOException Thrown in invalid numbers or unexpected end of JSON string
-     * */
+     */
     private Number readNumber() throws IOException {
-        StringBuffer sb = new StringBuffer();
-        int          l    = lineNo;
-        int          c    = colNo;
+        final StringBuilder sb = new StringBuilder();
+        int l = lineNo;
+        int c = colNo;
 
 
         boolean isHex = false;
-        
+
         if (lastChar == '-') {
-        	sb.append((char)lastChar);
+            sb.append((char) lastChar);
             readChar();
         }
         if (lastChar == '0') {
-        	sb.append((char)lastChar);
+            sb.append((char) lastChar);
             readChar();
-        	if (lastChar == 'x' || lastChar == 'X') {
-        		sb.append((char)lastChar);
+            if (lastChar == 'x' || lastChar == 'X') {
+                sb.append((char) lastChar);
                 readChar();
-        		isHex = true;
-        	}
+                isHex = true;
+            }
         }
-        
+
         if (isHex) {
-        	while (isDigitChar(lastChar) || isHexDigit(lastChar)) {
-                sb.append((char)lastChar);
+            while (isDigitChar(lastChar) || isHexDigit(lastChar)) {
+                sb.append((char) lastChar);
                 readChar();
-            }  	   
-        }
-        else {
+            }
+        } else {
             while (isDigitChar(lastChar)) {
-                sb.append((char)lastChar);
+                sb.append((char) lastChar);
                 readChar();
-            } 
+            }
         }
 
         // convert it!
@@ -394,51 +435,47 @@ public class Tokenizer {
             }
 
             if (isHex) {
-            	Long value = Long.valueOf(sign + string.substring(2),16);
-                if (value.longValue() <= Integer.MAX_VALUE  && (value.longValue() >= Integer.MIN_VALUE)) {
-                	return new Integer(value.intValue());
-                }
-                else {
-                	return value;
+                Long value = Long.valueOf(sign + string.substring(2), 16);
+                if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
+                    return Integer.valueOf(value.intValue());
+                } else {
+                    return value;
                 }
             }
 
             if (string.equals("0")) {
-                return new Integer(0);
+                return Integer.valueOf(0);
             } else if (string.startsWith("0") && string.length() > 1) {
-            	Long value = Long.valueOf(sign + string.substring(1),8);
-                if (value.longValue() <= Integer.MAX_VALUE  && (value.longValue() >= Integer.MIN_VALUE)) {
-                	return new Integer(value.intValue());
-                }
-                else {
-                	return value;
+                Long value = Long.valueOf(sign + string.substring(1), 8);
+                if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
+                    return Integer.valueOf(value.intValue());
+                } else {
+                    return value;
                 }
             }
 
-            /**
+            /*
              * We have to check for the exponential and treat appropriately
-             * Exponentials should be treated as Doubles.
+             * Exponential values should be treated as Doubles.
              */
-            if (string.indexOf("e") != -1 || string.indexOf("E") != -1) {
+            if (string.indexOf('e') != -1 || string.indexOf('E') != -1) {
                 return Double.valueOf(sign + string);
             } else {
-            	Long value = Long.valueOf(sign + string,10);
-                if (value.longValue() <= Integer.MAX_VALUE  && (value.longValue() >= Integer.MIN_VALUE)) {
-                	return new Integer(value.intValue());
-                }
-                else {
-                	return value;
+                Long value = Long.valueOf(sign + string, 10);
+                if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
+                    return Integer.valueOf(value.intValue());
+                } else {
+                    return value;
                 }
             }
         } catch (NumberFormatException e) {
-            IOException iox = new IOException("Invalid number literal " + onLineCol(l,c));
-            iox.initCause(e);
-            throw iox;
+            throw new IOException("Invalid number literal " + onLineCol(l, c), e);
         }
     }
 
     /**
-     * Method to indicate if the character read is a HEX digit or not. 
+     * Method to indicate if the character read is a HEX digit or not.
+     *
      * @param c The character to check for being a HEX digit.
      */
     private boolean isHexDigit(int c) {
@@ -447,7 +484,7 @@ public class Tokenizer {
             case '1':
             case '2':
             case '3':
-            case '4': 
+            case '4':
             case '5':
             case '6':
             case '7':
@@ -466,13 +503,14 @@ public class Tokenizer {
             case 'e':
             case 'f':
                 return true;
+            default:
+                return false;
         }
-
-        return false;
     }
 
     /**
-     * Method to indicate if the character read is an OCTAL digit or not. 
+     * Method to indicate if the character read is an OCTAL digit or not.
+     *
      * @param c The character to check for being a OCTAL digit.
      */
     private boolean isOctalDigit(int c) {
@@ -481,18 +519,19 @@ public class Tokenizer {
             case '1':
             case '2':
             case '3':
-            case '4': 
+            case '4':
             case '5':
             case '6':
-            case '7': 
+            case '7':
                 return true;
+            default:
+                return false;
         }
-
-        return false;
     }
 
     /**
-     * Method to indicate if the character read is a digit or not.  
+     * Method to indicate if the character read is a digit or not.
+     *
      * @param c The character to check for being a digit.
      */
     private boolean isDigitChar(int c) {
@@ -501,7 +540,7 @@ public class Tokenizer {
             case '1':
             case '2':
             case '3':
-            case '4': 
+            case '4':
             case '5':
             case '6':
             case '7':
@@ -515,29 +554,28 @@ public class Tokenizer {
             case '+':
             case '-':
                 return true;
+            default:
+                return false;
         }
-
-        return false;
     }
 
     /**
-     * Method to read a partular character string.
-     * only really need to handle 'null', 'true', and 'false' 
+     * Method to read a particular character string.
+     * only really need to handle 'null', 'true', and 'false'
      */
     private String readIdentifier() throws IOException {
-        StringBuffer sb = new StringBuffer();
-        
+        final StringBuilder sb = new StringBuilder();
+
         if (this.strict) {
-        	while ((-1 != lastChar) && (Character.isLetter((char)lastChar))) {
-                sb.append((char)lastChar);
+            while ((-1 != lastChar) && (Character.isLetter((char) lastChar))) {
+                sb.append((char) lastChar);
                 readChar();
             }
-        }
-        else {
-            while ((-1 != lastChar) && isValidUnquotedChar((char)lastChar)) {
-               sb.append((char)lastChar);
-               readChar();
-           }
+        } else {
+            while ((-1 != lastChar) && isValidUnquotedChar((char) lastChar)) {
+                sb.append((char) lastChar);
+                readChar();
+            }
         }
 
         return sb.toString();
@@ -545,7 +583,7 @@ public class Tokenizer {
 
     /**
      * Method to read the next character from the string, keeping track of line/column position.
-     * 
+     *
      * @throws IOException Thrown when underlying reader throws an error.
      */
     private void readChar() throws IOException {
@@ -554,7 +592,7 @@ public class Tokenizer {
             this.lineNo++;
         }
         lastChar = reader.read();
-        if (-1 == lastChar) return ;
+        if (-1 == lastChar) return;
         colNo++;
     }
 
@@ -569,11 +607,12 @@ public class Tokenizer {
      * Method to generate a String indicationg the current line and column position in the JSON string.
      */
     public String onLineCol() {
-        return onLineCol(lineNo,colNo);
+        return onLineCol(lineNo, colNo);
     }
 
     /**
      * High speed test for whitespace!  Faster than the java one (from some testing).
+     *
      * @return if the indicated character is whitespace.
      */
     public boolean isWhitespace(char c) {
@@ -592,31 +631,34 @@ public class Tokenizer {
                 //case Character.LINE_SEPARATOR:
             case Character.PARAGRAPH_SEPARATOR:
                 return true;
+            default:
+                return false;
         }
-        return false;
     }
-    
+
     /**
      * For non strict mode, check if char is valid when not quoted.
-     * @param c
+     *
+     * @param c char to evaluate
      * @return if character is valid unquoted character.
      */
     public boolean isValidUnquotedChar(char c) {
-    	
-    	if (Character.isLetterOrDigit(c)) {
-    		return true;
-    	}
-    	
-    	switch (c) {
-          case '@':  
-          case '-':  
-          case '.':  
-          case '$': 
-          case '+': 
-          case '!': 
-          case '_':
-              return true;
-    	}
-        return false; 
+
+        if (Character.isLetterOrDigit(c)) {
+            return true;
+        }
+
+        switch (c) {
+            case '@':
+            case '-':
+            case '.':
+            case '$':
+            case '+':
+            case '!':
+            case '_':
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/src/main/java/org/apache/wink/json4j/utils/XML.java
+++ b/src/main/java/org/apache/wink/json4j/utils/XML.java
@@ -110,13 +110,13 @@ public class XML {
     /**
      * Logger init.
      */
-    private static String  className              = "org.apache.commons.json.xml.transform.XML";
-    private static Logger logger                  = Logger.getLogger(className,null);
+    private static final String CLASS_NAME = "org.apache.commons.json.xml.transform.XML";
+    private static final Logger logger     = Logger.getLogger(CLASS_NAME,null);
 
     /**
      * Stylesheet for just doing indention.
      */
-    private static final String styleSheet= " <xsl:stylesheet version=\"1.0\"                                   \n" +
+    private static final String styleSheet = " <xsl:stylesheet version=\"1.0\"                                   \n" +
                                             "     xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">           \n" +
                                             "   <xsl:output method=\"xml\"/>                                    \n" +
                                             "   <xsl:param name=\"indent-increment\" select=\"'   '\" />        \n" +
@@ -163,12 +163,12 @@ public class XML {
      */
     public static void toJson(InputStream XMLStream, OutputStream JSONStream) throws SAXException, IOException {
         if (logger.isLoggable(Level.FINER)) {
-            logger.entering(className, "toJson(InputStream, OutputStream)");
+            logger.entering(CLASS_NAME, "toJson(InputStream, OutputStream)");
         }
         toJson(XMLStream,JSONStream,false);    
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.entering(className, "toJson(InputStream, OutputStream)");
+            logger.entering(CLASS_NAME, "toJson(InputStream, OutputStream)");
         }
     }
 
@@ -185,7 +185,7 @@ public class XML {
      */
     public static void toJson(InputStream XMLStream, OutputStream JSONStream, boolean verbose) throws SAXException, IOException {
         if (logger.isLoggable(Level.FINER)) {
-            logger.entering(className, "toJson(InputStream, OutputStream)");
+            logger.entering(CLASS_NAME, "toJson(InputStream, OutputStream)");
         }
 
         if (XMLStream == null) {
@@ -195,7 +195,7 @@ public class XML {
         } else {
 
             if (logger.isLoggable(Level.FINEST)) {
-                logger.logp(Level.FINEST, className, "transform", "Fetching a SAX parser for use with JSONSAXHandler");
+                logger.logp(Level.FINEST, CLASS_NAME, "transform", "Fetching a SAX parser for use with JSONSAXHandler");
             }
 
             try {
@@ -212,7 +212,7 @@ public class XML {
                 InputSource source = new InputSource(new BufferedInputStream(XMLStream));
 
                 if (logger.isLoggable(Level.FINEST)) {
-                    logger.logp(Level.FINEST, className, "transform", "Parsing the XML content to JSON");
+                    logger.logp(Level.FINEST, CLASS_NAME, "transform", "Parsing the XML content to JSON");
                 }
 
                 /** 
@@ -227,7 +227,7 @@ public class XML {
         }
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toJson(InputStream, OutputStream)");
+            logger.exiting(CLASS_NAME, "toJson(InputStream, OutputStream)");
         }
     }
 
@@ -258,7 +258,7 @@ public class XML {
      */                                                                    
     public static String toJson(InputStream xmlStream, boolean verbose)  throws SAXException, IOException {
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toJson(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toJson(InputStream, boolean)");
         }
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -275,7 +275,7 @@ public class XML {
         }
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toJson(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toJson(InputStream, boolean)");
         }
 
         return result;
@@ -294,7 +294,7 @@ public class XML {
      */
     public static String toJson(File xmlFile, boolean verbose) throws SAXException, IOException {
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toJson(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toJson(InputStream, boolean)");
         }
 
         FileInputStream fis        = new FileInputStream(xmlFile);
@@ -304,7 +304,7 @@ public class XML {
         fis.close();
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toJson(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toJson(InputStream, boolean)");
         }
 
         return result;
@@ -337,12 +337,12 @@ public class XML {
     throws IOException
     {
         if (logger.isLoggable(Level.FINER)) {
-            logger.entering(className, "toXml(InputStream, OutputStream)");
+            logger.entering(CLASS_NAME, "toXml(InputStream, OutputStream)");
         }
         toXml(JSONStream,XMLStream,false);    
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.entering(className, "toXml(InputStream, OutputStream)");
+            logger.entering(CLASS_NAME, "toXml(InputStream, OutputStream)");
         }
     }
 
@@ -360,7 +360,7 @@ public class XML {
     throws IOException
     {
         if (logger.isLoggable(Level.FINER)) {
-            logger.entering(className, "toXml(InputStream, OutputStream)");
+            logger.entering(CLASS_NAME, "toXml(InputStream, OutputStream)");
         }
 
         if (XMLStream == null) {
@@ -370,7 +370,7 @@ public class XML {
         } else {
 
             if (logger.isLoggable(Level.FINEST)) {
-                logger.logp(Level.FINEST, className, "transform", "Parsing the JSON and a DOM builder.");
+                logger.logp(Level.FINEST, CLASS_NAME, "transform", "Parsing the JSON and a DOM builder.");
             }
 
             try {
@@ -384,7 +384,7 @@ public class XML {
                 Document doc = dBuilder.newDocument();
 
                 if (logger.isLoggable(Level.FINEST)) {
-                    logger.logp(Level.FINEST, className, "transform", "Parsing the JSON content to XML");
+                    logger.logp(Level.FINEST, CLASS_NAME, "transform", "Parsing the JSON content to XML");
                 }
 
                 convertJSONObject(doc, doc.getDocumentElement(), jObject, "jsonObject");
@@ -413,7 +413,7 @@ public class XML {
         }
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toXml(InputStream, OutputStream)");
+            logger.exiting(CLASS_NAME, "toXml(InputStream, OutputStream)");
         }
     }
 
@@ -446,7 +446,7 @@ public class XML {
     throws IOException
     {
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toXml(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toXml(InputStream, boolean)");
         }
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -463,7 +463,7 @@ public class XML {
         }
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toXml(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toXml(InputStream, boolean)");
         }
 
         return result;
@@ -483,7 +483,7 @@ public class XML {
     throws IOException
     {
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toXml(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toXml(InputStream, boolean)");
         }
 
         FileInputStream fis        = new FileInputStream(jsonFile);
@@ -493,7 +493,7 @@ public class XML {
         fis.close();
 
         if (logger.isLoggable(Level.FINER)) {
-            logger.exiting(className, "toXml(InputStream, boolean)");
+            logger.exiting(CLASS_NAME, "toXml(InputStream, boolean)");
         }
 
         return result;

--- a/src/main/java/org/apache/wink/json4j/utils/internal/JSONObject.java
+++ b/src/main/java/org/apache/wink/json4j/utils/internal/JSONObject.java
@@ -21,10 +21,7 @@ package org.apache.wink.json4j.utils.internal;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.Properties;
-import java.util.Vector;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,30 +30,32 @@ import java.util.logging.Logger;
  * This class is lightweight representation of an XML tag as a JSON object.
  * TODO:  Look at using HashMap and collections to store the data instead of sync'ed objects.
  * TODO:  See if the indent/newline handling could be cleaned up.  the repeated checks for compact is rather ugly.
- * TODO:  Look at maybe using the Java representation object as store for the XML data intsead of this customized object.
+ * TODO:  Look at maybe using the Java representation object as store for the XML data instead of this customized object.
  */
 public class JSONObject {
     /**
      * Logger.
      */
-    private static String  className              = "org.apache.commons.json.uils.xml.internal.JSONObject";
-    private static Logger logger                  = Logger.getLogger(className,null);
-    private static final String indent            = "   ";
+    private static final String CLASS_NAME      = "org.apache.commons.json.uils.xml.internal.JSONObject";
+    private static Logger logger                = Logger.getLogger(CLASS_NAME,null);
+    private static final String DEFAULT_INDENT  = "   ";
+
+    private static final String ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT = "Error occurred on serialization of JSON text.";
 
     /**
      * The JSON object name.  Effectively, the XML tag name.
      */
-    private String objectName     = null;
+    private final String objectName;
 
     /**
      * All basic JSON object properties.  Effectively same as XML tag attributes.
      */
-    private Properties attrs      = null;
+    private final Properties attrs;
 
     /**
      * All children JSON objects referenced.  Effectively the child tags of an XML tag.
      */
-    private Hashtable jsonObjects = null;
+    private final Hashtable jsonObjects;
 
     /**
      * Any XML freeform text to associate with the JSON object,
@@ -66,7 +65,7 @@ public class JSONObject {
     /**
      * Constructor.
      * @param objectName The object (tag) name being constructed.
-     * @param attrs A proprerties object of all the attributes present for the tag.
+     * @param attrs A properties object of all the attributes present for the tag.
      */
     public JSONObject(String objectName, Properties attrs) {
         this.objectName  = objectName;
@@ -79,7 +78,7 @@ public class JSONObject {
      * @param obj The child JSON object to add to this JSON object.
      */
     public void addJSONObject(JSONObject obj) {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "addJSONObject(JSONObject)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "addJSONObject(JSONObject)");
 
         Vector vect = (Vector) this.jsonObjects.get(obj.objectName);
         if (vect != null) {
@@ -90,7 +89,7 @@ public class JSONObject {
             this.jsonObjects.put(obj.objectName, vect);
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "addJSONObject(JSONObject)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "addJSONObject(JSONObject)");
     }
 
     /**
@@ -117,9 +116,9 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     public void writeObject(Writer writer, int indentDepth, boolean contentOnly) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeObject(Writer, int, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeObject(Writer, int, boolean)");
         writeObject(writer,indentDepth,contentOnly, false);
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeObject(Writer, int, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeObject(Writer, int, boolean)");
     }
 
 
@@ -132,7 +131,7 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     public void writeObject(Writer writer, int indentDepth, boolean contentOnly, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeObject(Writer, int, boolean, boolean)");
 
         if (writer != null) {
             try {
@@ -145,7 +144,7 @@ public class JSONObject {
                 }
 
             } catch (Exception ex) {
-                IOException iox = new IOException("Error occurred on serialization of JSON text.");
+                IOException iox = new IOException(ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT);
                 iox.initCause(ex);
                 throw iox;
             }
@@ -153,7 +152,7 @@ public class JSONObject {
             throw new IOException("The writer cannot be null.");
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeObject(Writer, int, boolean, boolean)");
     }
 
     /**
@@ -166,7 +165,7 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeAttribute(Writer writer, String name, String value, int depth, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeAttribute(Writer, String, String, int)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeAttribute(Writer, String, String, int)");
 
         if (!compact) {
             writeIndention(writer, depth);
@@ -179,12 +178,12 @@ public class JSONObject {
                 writer.write("\"" + name + "\"" + ":" + "\"" + escapeStringSpecialCharacters(value) + "\"");
             }
         } catch (Exception ex) {
-            IOException iox = new IOException("Error occurred on serialization of JSON text.");
+            IOException iox = new IOException(ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT);
             iox.initCause(ex);
             throw iox;
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeAttribute(Writer, String, String, int)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeAttribute(Writer, String, String, int)");
     }
 
     /**
@@ -194,19 +193,19 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeIndention(Writer writer, int indentDepth) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeIndention(Writer, int)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeIndention(Writer, int)");
 
         try {
             for (int i = 0; i < indentDepth; i++) {
-                writer.write(indent);
+                writer.write(DEFAULT_INDENT);
             }
         } catch (Exception ex) {
-            IOException iox = new IOException("Error occurred on serialization of JSON text.");
+            IOException iox = new IOException(ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT);
             iox.initCause(ex);
             throw iox;
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeIndention(Writer, int)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeIndention(Writer, int)");
     }
 
     /**
@@ -218,7 +217,7 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeAttributes(Writer writer, Properties attrs, int depth, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeAttributes(Writer, Properties, int, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeAttributes(Writer, Properties, int, boolean)");
 
         if (attrs != null) {
             Enumeration props = attrs.propertyNames();
@@ -235,7 +234,7 @@ public class JSONObject {
                                 writer.write(",");
                             }
                         } catch (Exception ex) {
-                            IOException iox = new IOException("Error occurred on serialization of JSON text.");
+                            IOException iox = new IOException(ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT);
                             iox.initCause(ex);
                             throw iox;
                         }
@@ -244,7 +243,7 @@ public class JSONObject {
             }
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeAttributes(Writer, Properties, int, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeAttributes(Writer, Properties, int, boolean)");
     }
 
     /**
@@ -282,7 +281,7 @@ public class JSONObject {
      * @param str The string to escape the characters in.
      */
     private String escapeStringSpecialCharacters(String str) {
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "escapeStringSpecialCharacters(String)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "escapeStringSpecialCharacters(String)");
 
         if (str != null) {
             StringBuffer strBuf = new StringBuffer("");
@@ -345,7 +344,7 @@ public class JSONObject {
             }
             str = strBuf.toString();
         }
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "escapeStringSpecialCharacters(String)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "escapeStringSpecialCharacters(String)");
         return str;
     }
 
@@ -357,7 +356,7 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeChildren(Writer writer, int depth, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeChildren(Writer, int, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeChildren(Writer, int, boolean)");
 
         if (!jsonObjects.isEmpty()) {
             Enumeration keys = jsonObjects.keys();
@@ -369,7 +368,7 @@ public class JSONObject {
                      * Non-array versus array elements.
                      */
                     if (vect.size() == 1) {
-                        if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, className, "writeChildren(Writer, int, boolean)", "Writing child object: [" + objName + "]");
+                        if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, CLASS_NAME, "writeChildren(Writer, int, boolean)", "Writing child object: [" + objName + "]");
 
                         JSONObject obj = (JSONObject)vect.elementAt(0);
                         obj.writeObject(writer,depth + 1, false, compact);
@@ -384,7 +383,7 @@ public class JSONObject {
                                     writer.write(",");
                                 }
                             } catch (Exception ex) {
-                                IOException iox = new IOException("Error occurred on serialization of JSON text.");
+                                IOException iox = new IOException(ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT);
                                 iox.initCause(ex);
                                 throw iox;
                             }
@@ -394,7 +393,7 @@ public class JSONObject {
                             }
                         }
                     } else {
-                        if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, className, "writeChildren(Writer, int, boolean)", "Writing array of JSON objects with attribute name: [" + objName + "]");
+                        if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, CLASS_NAME, "writeChildren(Writer, int, boolean)", "Writing array of JSON objects with attribute name: [" + objName + "]");
 
                         try {
                             if (!compact) {
@@ -438,7 +437,7 @@ public class JSONObject {
                                 writer.write("\n");
                             }
                         } catch (Exception ex) {
-                            IOException iox = new IOException("Error occurred on serialization of JSON text.");
+                            IOException iox = new IOException(ERROR_OCCURRED_ON_SERIALIZATION_OF_JSON_TEXT);
                             iox.initCause(ex);
                             throw iox;
                         }
@@ -447,7 +446,7 @@ public class JSONObject {
             }
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeChildren(Writer, int, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeChildren(Writer, int, boolean)");
     }
 
     /**
@@ -459,7 +458,7 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeEmptyObject(Writer writer, int indentDepth, boolean contentOnly, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeEmptyObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeEmptyObject(Writer, int, boolean, boolean)");
 
         if (!contentOnly) {
             if (!compact) {
@@ -480,7 +479,7 @@ public class JSONObject {
             }
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeEmptyObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeEmptyObject(Writer, int, boolean, boolean)");
     }
 
     /**
@@ -492,7 +491,7 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeTextOnlyObject(Writer writer, int indentDepth, boolean contentOnly, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeTextOnlyObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeTextOnlyObject(Writer, int, boolean, boolean)");
 
         if (!contentOnly) {
             writeAttribute(writer,this.objectName,this.tagText.trim(),indentDepth, compact);
@@ -505,7 +504,7 @@ public class JSONObject {
             }
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeTextOnlyObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeTextOnlyObject(Writer, int, boolean, boolean)");
     }
 
     /**
@@ -517,12 +516,12 @@ public class JSONObject {
      * @throws IOException Trhown if an error occurs on write.
      */
     private void writeComplexObject(Writer writer, int indentDepth, boolean contentOnly, boolean compact) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "writeComplexObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "writeComplexObject(Writer, int, boolean, boolean)");
 
         boolean wroteTagText = false;
 
         if (!contentOnly) {
-            if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, className, "writeComplexObject(Writer, int, boolean, boolean)", "Writing object: [" + this.objectName + "]");
+            if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, CLASS_NAME, "writeComplexObject(Writer, int, boolean, boolean)", "Writing object: [" + this.objectName + "]");
 
             if (!compact) {
                 writeIndention(writer, indentDepth);
@@ -536,7 +535,7 @@ public class JSONObject {
                 writer.write(":{");
             }
         } else {
-            if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, className, "writeObject(Writer, int, boolean, boolean)", "Writing object contents as an anonymous object (usually an array entry)");
+            if (logger.isLoggable(Level.FINEST)) logger.logp(Level.FINEST, CLASS_NAME, "writeObject(Writer, int, boolean, boolean)", "Writing object contents as an anonymous object (usually an array entry)");
 
             if (!compact) {
                 writeIndention(writer, indentDepth);
@@ -588,7 +587,7 @@ public class JSONObject {
             writer.write("}");
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "writeComplexObject(Writer, int, boolean, boolean)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "writeComplexObject(Writer, int, boolean, boolean)");
     }
 
 

--- a/src/main/java/org/apache/wink/json4j/utils/internal/JSONSAXHandler.java
+++ b/src/main/java/org/apache/wink/json4j/utils/internal/JSONSAXHandler.java
@@ -22,6 +22,7 @@ package org.apache.wink.json4j.utils.internal;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.Stack;
 import java.util.logging.Level;
@@ -33,19 +34,19 @@ import org.xml.sax.helpers.DefaultHandler;
 
 
 /**
- * This class is a SAX entension to do conversion of XML to JSON.
+ * This class is a SAX extension to do conversion of XML to JSON.
  */
 public class JSONSAXHandler extends DefaultHandler {
     /**
      * Logger code
      */
-    private static String  className              = "org.apache.commons.json.utils.xml.transform.impl.JSONSAXHandler";
-    private static Logger logger                  = Logger.getLogger(className,null);
+    private static final String CLASS_NAME = "org.apache.commons.json.utils.xml.transform.impl.JSONSAXHandler";
+    private static final Logger logger                  = Logger.getLogger(CLASS_NAME,null);
 
     /**
      * The writer to stream the JSON text out to.
      */
-    private OutputStreamWriter osWriter           = null;
+    private final OutputStreamWriter osWriter;
 
     /**
      * The current JSON object being constructed from the current TAG being parsed.
@@ -70,38 +71,42 @@ public class JSONSAXHandler extends DefaultHandler {
     /**
      * Constructor.
      * @param os The outputStream to write the resulting JSON to.  Same as JSONSAXHander(os,false);
-     * @throws IOException Thrown if an error occurs during streaming out, or XML read.
      */
-    public JSONSAXHandler(OutputStream os) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "JSONHander(OutputStream) <constructor>");
+    public JSONSAXHandler(OutputStream os)  {
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "JSONSAXHandler(OutputStream) <constructor>");
 
-        this.osWriter = new OutputStreamWriter(os,"UTF-8");
+        this.osWriter = new OutputStreamWriter(os, StandardCharsets.UTF_8);
         this.compact  = true;
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "JSONHander(OutputStream) <constructor>");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "JSONSAXHandler(OutputStream) <constructor>");
     }
 
     /**
      * Constructor.
      * @param os The outputStream to write the resulting JSON to
-     * @param verbose Whenther or not to render the stream in a verbose (formatted), or compact form.
-     * @throws IOException Thrown if an error occurs during streaming out, or XML read.
+     * @param verbose Whether or not to render the stream in a verbose (formatted), or compact form.
      */
-    public JSONSAXHandler(OutputStream os, boolean verbose) throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "JSONHander(OutputStream, boolean) <constructor>");
+    public JSONSAXHandler(OutputStream os, boolean verbose) {
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "JSONSAXHandler(OutputStream, boolean) <constructor>");
 
-        this.osWriter = new OutputStreamWriter(os,"UTF-8");
+        this.osWriter = new OutputStreamWriter(os,StandardCharsets.UTF_8);
         this.compact  = !verbose;
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "JSONHander(OutputStream, boolean) <constructor>");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "JSONSAXHandler(OutputStream, boolean) <constructor>");
     }
 
 
     /**
-     * This function parses an IFix top level element and all its children.
+     * This function parses an iFix top level element and all its children.
+     *
+     * @param namespaceURI namespace
+     * @param localName local name
+     * @param qName q name
+     * @param attrs attributes
+     * @throws SAXException
      */
     public void startElement(String namespaceURI, String localName, String qName, Attributes attrs) throws SAXException {
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "startElement(String,String,String,org.xml.sax.Attributes)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "startElement(String,String,String,org.xml.sax.Attributes)");
 
         Properties props = new Properties();
         int attrLength = attrs.getLength();
@@ -121,14 +126,14 @@ public class JSONSAXHandler extends DefaultHandler {
             this.current  = obj;
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "startElement(String,String,String,org.xml.sax.Attributes)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "startElement(String,String,String,org.xml.sax.Attributes)");
     }
 
     /**
      * Function ends a tag in this iFix parser.
      */
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "endElement(String,String,String)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "endElement(String,String,String)");
 
         if (!previousObjects.isEmpty()) {
             this.current = (JSONObject)this.previousObjects.pop();
@@ -136,14 +141,14 @@ public class JSONSAXHandler extends DefaultHandler {
             this.current = null;
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "endElement(String,String,String)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "endElement(String,String,String)");
     }
 
     public void characters(char[] ch,
                            int start,
                            int length)
     throws SAXException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "characters(char[], int, int)");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "characters(char[], int, int)");
 
         String str = new String(ch,start,length);
         if (this.current.getTagText() != null) {
@@ -151,23 +156,23 @@ public class JSONSAXHandler extends DefaultHandler {
         }
         this.current.setTagText(str);
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "characters(char[], int, int)");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "characters(char[], int, int)");
     }
 
     public void startDocument() throws SAXException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "startDocument()");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "startDocument()");
 
         startJSON();
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "startDocument()");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "startDocument()");
     }
 
     public void endDocument() throws SAXException {
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "endDocument()");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "endDocument()");
 
         endJSON();
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "endDocument()");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "endDocument()");
     }
 
     /**
@@ -175,25 +180,39 @@ public class JSONSAXHandler extends DefaultHandler {
      * @throws IOException Thrown if there is an error while flushing buffer
      */
     public void flushBuffer() throws IOException {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "flushBuffer()");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "flushBuffer()");
 
         if (this.osWriter != null) {
             this.osWriter.flush();
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "flushBuffer()");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "flushBuffer()");
+    }
+
+    /**
+     * Close all buffers
+     * @throws IOException
+     */
+    public void close() throws IOException {
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "close()");
+
+        if (this.osWriter != null) {
+            this.osWriter.close();
+        }
+
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "close()");
     }
 
     /**
      * Internal method to start JSON generation.
      */
     private void startJSON() {
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "startJSON()");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "startJSON()");
 
         this.head    = new JSONObject("",null);
         this.current = head;
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "startJSON()");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "startJSON()");
     }
 
     /**
@@ -201,7 +220,7 @@ public class JSONSAXHandler extends DefaultHandler {
      * and reset the internal state of the hander.
      */
     private void endJSON() throws SAXException {   
-        if (logger.isLoggable(Level.FINER)) logger.entering(className, "endJSON()");
+        if (logger.isLoggable(Level.FINER)) logger.entering(CLASS_NAME, "endJSON()");
 
         try {
             this.head.writeObject(this.osWriter, 0, true, this.compact);
@@ -214,7 +233,7 @@ public class JSONSAXHandler extends DefaultHandler {
             throw saxEx;
         }
 
-        if (logger.isLoggable(Level.FINER)) logger.exiting(className, "endJSON()");
+        if (logger.isLoggable(Level.FINER)) logger.exiting(CLASS_NAME, "endJSON()");
     }
 
 }

--- a/src/test/java/org/apache/wink/json4j/compat/tests/ApacheJSONArrayTest.java
+++ b/src/test/java/org/apache/wink/json4j/compat/tests/ApacheJSONArrayTest.java
@@ -304,7 +304,7 @@ public class ApacheJSONArrayTest extends TestCase {
             JSONArray obj = (JSONArray)jArray.get(0);
             assertTrue(obj != null);
             assertTrue(obj instanceof JSONArray);
-            assertTrue(((JSONArray)jArray.get(0)).toString().equals("[]"));
+            assertEquals("[]", jArray.get(0).toString());
         } catch (Exception ex1) {
             ex = ex1;
             ex.printStackTrace();
@@ -725,7 +725,7 @@ public class ApacheJSONArrayTest extends TestCase {
             JSONFactory factory = JSONFactory.newInstance();
             JSONArray jArray = factory.createJSONArray("[1, true, false, null, \"My String\", [1,2,3], {\"foo\":\"bar\"}]");
             String joined = jArray.join("");
-            assertTrue(joined.equals("1truefalsenullMy String[1,2,3]{\"foo\":\"bar\"}"));
+            assertEquals("1truefalsenullMy String[1,2,3]{\"foo\":\"bar\"}", joined);
         } catch (Exception ex1) {
             ex = ex1;
             ex.printStackTrace();
@@ -743,7 +743,7 @@ public class ApacheJSONArrayTest extends TestCase {
             JSONFactory factory = JSONFactory.newInstance();
             JSONArray jArray = factory.createJSONArray("[1, true, false, null, \"My String\", [1,2,3], {\"foo\":\"bar\"}]");
             String joined = jArray.join("|");
-            assertTrue(joined.equals("1|true|false|null|My String|[1,2,3]|{\"foo\":\"bar\"}"));
+            assertEquals("1|true|false|null|My String|[1,2,3]|{\"foo\":\"bar\"}", joined);
         } catch (Exception ex1) {
             ex = ex1;
             ex.printStackTrace();

--- a/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderTest.java
+++ b/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderTest.java
@@ -34,6 +34,7 @@ public class FormatOptionsBuilderTest {
                 .setFormat(FormatOptions.Format.Verbose)
                 .setEmptyArrayOnSameLine(true)
                 .setEscapeForwardSlashes(false)
+                .setSpaceBetweenKeyAndColon(true)
                 .setIndentString("  ")
                 .setNewlineString("\t")
                 .build();
@@ -41,7 +42,18 @@ public class FormatOptionsBuilderTest {
         assertTrue(formatOptions.isVerbose());
         assertTrue(formatOptions.emptyObjectsAndArrayClosuresOnSameLine());
         assertFalse(formatOptions.escapeForwardSlashes());
+        assertTrue(formatOptions.spaceBetweenKeyAndColon());
         assertEquals("  ", formatOptions.indentString());
         assertEquals("\t", formatOptions.newline());
+    }
+    @Test
+    public void testBasic_returnsDefaults() throws Exception {
+        final FormatOptions formatOptions = FormatOptionsBuilder.basic();
+        assertTrue(formatOptions.isCompact());
+        assertFalse(formatOptions.emptyObjectsAndArrayClosuresOnSameLine());
+        assertTrue(formatOptions.escapeForwardSlashes());
+        assertFalse(formatOptions.spaceBetweenKeyAndColon());
+        assertEquals("\t", formatOptions.indentString());
+        assertEquals(System.lineSeparator(), formatOptions.newline());
     }
 }

--- a/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderTest.java
+++ b/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsBuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.formatter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FormatOptionsBuilderTest {
+
+    @Test
+    public void testBuild() throws Exception {
+        FormatOptionsBuilder builder = new FormatOptionsBuilderImpl();
+        FormatOptions formatOptions = builder
+                .setFormat(FormatOptions.Format.Verbose)
+                .setEmptyArrayOnSameLine(true)
+                .setEscapeForwardSlashes(false)
+                .setIndentString("  ")
+                .setNewlineString("\t")
+                .build();
+
+        assertTrue(formatOptions.isVerbose());
+        assertTrue(formatOptions.emptyObjectsAndArrayClosuresOnSameLine());
+        assertFalse(formatOptions.escapeForwardSlashes());
+        assertEquals("  ", formatOptions.indentString());
+        assertEquals("\t", formatOptions.newline());
+    }
+}

--- a/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsImplTest.java
+++ b/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsImplTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.formatter;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+public class FormatOptionsImplTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private FormatOptionsImpl target;
+
+    @Before
+    public void setUp() {
+        target = new FormatOptionsImpl();
+    }
+
+    @Test
+    public void testFormatOptionDefaults() throws Exception {
+        assertTrue(target.escapeForwardSlashes());
+        assertFalse(target.emptyObjectsAndArrayClosuresOnSameLine());
+        assertTrue(target.isCompact());
+        assertFalse(target.isVerbose());
+        assertEquals("\t", target.indentString());
+        assertEquals(System.lineSeparator(), target.newline());
+    }
+
+    @Test
+    public void setEmptyArrayOnSameLine_returnsObject() throws Exception {
+        assertEquals(target, target.setEmptyObjectsAndArrayClosuresOnSameLine(true));
+        assertTrue(target.emptyObjectsAndArrayClosuresOnSameLine());
+    }
+
+    @Test
+    public void setEscapeForwardSlashes_returnsObject() throws Exception {
+        assertEquals(target, target.setEscapeForwardSlashes(false));
+        assertFalse(target.escapeForwardSlashes());
+    }
+
+    @Test
+    public void setIndentString_returnsObject() throws Exception {
+        assertEquals(target, target.setIndentString("  "));
+        assertEquals("  ", target.indentString());
+    }
+
+    @Test
+    public void setIndentString_withNull_throwsException() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("indent string cannot be null");
+        target.setIndentString(null);
+    }
+
+    @Test
+    public void setFormat_returnsObject() throws Exception {
+        assertEquals(target, target.setFormat(FormatOptions.Format.Compact));
+    }
+
+    @Test
+    public void isCompact() throws Exception {
+        target.setFormat(FormatOptions.Format.Compact);
+        assertTrue(target.isCompact());
+    }
+
+    @Test
+    public void isVerbose() throws Exception {
+        target.setFormat(FormatOptions.Format.Verbose);
+        assertTrue(target.isVerbose());
+    }
+
+    @Test
+    public void setNewline_returnsObject() throws Exception {
+        assertEquals(target, target.setNewline("\n"));
+        assertEquals("\n", target.newline());
+    }
+
+    @Test
+    public void setNewline_withNull_throwsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("newline string cannot be null");
+        target.setNewline(null);
+    }
+
+}

--- a/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsImplTest.java
+++ b/src/test/java/org/apache/wink/json4j/formatter/FormatOptionsImplTest.java
@@ -40,8 +40,9 @@ public class FormatOptionsImplTest {
 
     @Test
     public void testFormatOptionDefaults() throws Exception {
-        assertTrue(target.escapeForwardSlashes());
         assertFalse(target.emptyObjectsAndArrayClosuresOnSameLine());
+        assertTrue(target.escapeForwardSlashes());
+        assertFalse(target.spaceBetweenKeyAndColon());
         assertTrue(target.isCompact());
         assertFalse(target.isVerbose());
         assertEquals("\t", target.indentString());
@@ -58,6 +59,12 @@ public class FormatOptionsImplTest {
     public void setEscapeForwardSlashes_returnsObject() throws Exception {
         assertEquals(target, target.setEscapeForwardSlashes(false));
         assertFalse(target.escapeForwardSlashes());
+    }
+
+    @Test
+    public void setSpaceBetweenKeyAndColon_returnsObject() throws Exception {
+        assertEquals(target, target.setSpaceBetweenKeyAndColon(false));
+        assertFalse(target.spaceBetweenKeyAndColon());
     }
 
     @Test

--- a/src/test/java/org/apache/wink/json4j/tests/BeanSerializerTest.java
+++ b/src/test/java/org/apache/wink/json4j/tests/BeanSerializerTest.java
@@ -35,9 +35,9 @@ import static org.junit.Assert.*;
 /**
  * Tests for the basic Java Bean serializer
  * <p>
- * Note: Using the java Date class is a bad example because the <code>BeanSerializer</code>
+ * Note: Using the java Date class is a bad example because the <tt>BeanSerializer</tt>
  * looks at the getXXXX methods, then stick the value in a map with a key of XXXX.
- * <code>java.util.Date</code> has deprecated get methods making this difficult
+ * <tt>java.util.Date</tt> has deprecated get methods making this difficult
  * and confusing to test with this object.
  */
 public class BeanSerializerTest {

--- a/src/test/java/org/apache/wink/json4j/tests/JSONArrayTest.java
+++ b/src/test/java/org/apache/wink/json4j/tests/JSONArrayTest.java
@@ -220,7 +220,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test parsing a value which ia a number bigger than <code>Long.MAX_VALUE</code>
+     * Test parsing a value which ia a number bigger than <tt>Long.MAX_VALUE</tt>
      */
     @Test
     public void test_parseNumberGreaterThanMaxLong_throwsException() throws JSONException {
@@ -230,7 +230,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test parsing a value which ia a number smaller than <code>Long.MIN_VALUE</code>
+     * Test parsing a value which ia a number smaller than <tt>Long.MIN_VALUE</tt>
      */
     @Test
     public void test_parseNumberLessThanMinLong_throwsException() throws JSONException {
@@ -279,7 +279,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getLong</code> with <code>Long.MAX_VALUE</code>
+     * Test <tt>getLong</tt> with <tt>Long.MAX_VALUE</tt>
      */
     @Test
     public void test_getMaxLongPositive() throws JSONException {
@@ -287,7 +287,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getLong</code> with <code>Long.MIN_VALUE</code>
+     * Test <tt>getLong</tt> with <tt>Long.MIN_VALUE</tt>
      */
     @Test
     public void test_getMaxLongNegative() throws JSONException {
@@ -295,7 +295,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getInt</code> with <code>Integer.MAX_VALUE</code>
+     * Test <tt>getInt</tt> with <tt>Integer.MAX_VALUE</tt>
      */
     @Test
     public void test_getMaxIntPositive() throws JSONException {
@@ -303,7 +303,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getInt</code> with <code>Integer.MIN_VALUE</code>
+     * Test <tt>getInt</tt> with <tt>Integer.MIN_VALUE</tt>
      */
     @Test
     public void test_getMaxIntNegative() throws JSONException {
@@ -311,7 +311,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getInt</code> with number bigger than <code>Integer.MAX_VALUE</code>
+     * Test <tt>getInt</tt> with number bigger than <tt>Integer.MAX_VALUE</tt>
      */
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     @Test
@@ -323,7 +323,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal
+     * Test <tt>getDouble</tt> with double decimal
      */
     @Test
     public void test_getPositiveDoubleWithDecimal() throws JSONException {
@@ -331,7 +331,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal
+     * Test <tt>getDouble</tt> with negative double decimal
      */
     @Test
     public void test_getNegativeDoubleWithDecimal() throws JSONException {
@@ -339,7 +339,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal with an exponent (eg. e-3)
+     * Test <tt>getDouble</tt> with double decimal with an exponent (eg. e-3)
      */
     @Test
     public void test_getPositiveDoubleWithExponential() throws JSONException {
@@ -348,7 +348,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal with an exponent (eg. e-3)
+     * Test <tt>getDouble</tt> with negative double decimal with an exponent (eg. e-3)
      */
     @Test
     public void test_getNegativeDoubleWithExponential() throws JSONException {
@@ -357,7 +357,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal with an exponent (eg. e+3)
+     * Test <tt>getDouble</tt> with double decimal with an exponent (eg. e+3)
      */
     @Test
     public void test_getPositiveDoubleWithPlusExponential() throws JSONException {
@@ -366,7 +366,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal with an exponent (eg. e+3)
+     * Test <tt>getDouble</tt> with negative double decimal with an exponent (eg. e+3)
      */
     @Test
     public void test_getNegativeDoubleWithPlusExponential() throws JSONException {
@@ -375,7 +375,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code>
+     * Test <tt>getBoolean</tt>
      */
     @Test
     public void test_getBoolean() throws JSONException {
@@ -384,7 +384,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code> with strings <code>"true"</code> and  <code>"false"</code>
+     * Test <tt>getBoolean</tt> with strings <tt>"true"</tt> and  <tt>"false"</tt>
      */
     @Test
     public void test_getBoolean_StringValue() throws JSONException {
@@ -393,7 +393,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code> with string <code>"True"</code> throws exception
+     * Test <tt>getBoolean</tt> with string <tt>"True"</tt> throws exception
      */
     @Test
     public void test_getBoolean_IllegalStringValue_True_throwsJSONException() throws Exception {
@@ -403,7 +403,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code> with string <code>"False"</code> throws exception
+     * Test <tt>getBoolean</tt> with string <tt>"False"</tt> throws exception
      *
      * @throws Exception shouldn't be thrown
      */
@@ -415,7 +415,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code> with string <code>"False"</code> throws exception
+     * Test <tt>getBoolean</tt> with string <tt>"False"</tt> throws exception
      *
      * @throws Exception shouldn't be thrown
      */
@@ -427,7 +427,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>get</code> with a null member
+     * Test <tt>get</tt> with a null member
      */
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     @Test
@@ -468,7 +468,7 @@ public class JSONArrayTest {
     /* *********************************************************************** */
 
     /**
-     * Test <code>getLong</code> function failure due to type mismatch
+     * Test <tt>getLong</tt> function failure due to type mismatch
      */
     @Test
     public void test_getLong_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -478,7 +478,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> function failure due to type mismatch
+     * Test <tt>getDouble</tt> function failure due to type mismatch
      */
     @Test
     public void test_getDouble_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -488,7 +488,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getInt</code> function failure due to type mismatch
+     * Test <tt>getInt</tt> function failure due to type mismatch
      */
     @Test
     public void test_getInt_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -498,7 +498,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getShort</code> function failure due to type mismatch
+     * Test <tt>getShort</tt> function failure due to type mismatch
      */
     @Test
     public void test_getShort_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -508,7 +508,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getShort</code> function failure due to type mismatch
+     * Test <tt>getShort</tt> function failure due to type mismatch
      */
     @Test
     public void test_getString_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -518,7 +518,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getString</code> function returns string representation of number
+     * Test <tt>getString</tt> function returns string representation of number
      */
     @Test
     public void test_getString_returnsIntegerToString() throws JSONException {
@@ -526,7 +526,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code> function failure due to type mismatch
+     * Test <tt>getBoolean</tt> function failure due to type mismatch
      */
     @Test
     public void test_getBoolean_typeMisMatchNumber_throwsJSONException() throws JSONException {
@@ -536,7 +536,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getLong</code> function failure due to value null
+     * Test <tt>getLong</tt> function failure due to value null
      */
     @Test
     public void test_getLong_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -546,7 +546,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getInt</code> function failure due to value null
+     * Test <tt>getInt</tt> function failure due to value null
      */
     @Test
     public void test_getInt_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -556,7 +556,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getDouble</code> function failure due to value null
+     * Test <tt>getDouble</tt> function failure due to value null
      */
     @Test
     public void test_getDouble_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -566,7 +566,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getShort</code> function failure due to value null
+     * Test <tt>getShort</tt> function failure due to value null
      */
     @Test
     public void test_getShort_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -576,7 +576,7 @@ public class JSONArrayTest {
     }
 
     /**
-     * Test <code>getBoolean</code> function failure due to value null
+     * Test <tt>getBoolean</tt> function failure due to value null
      */
     @Test
     public void test_getBoolean_typeMisMatchNull_throwsJSONException() throws JSONException {

--- a/src/test/java/org/apache/wink/json4j/tests/JSONObjectTest.java
+++ b/src/test/java/org/apache/wink/json4j/tests/JSONObjectTest.java
@@ -22,6 +22,8 @@ package org.apache.wink.json4j.tests;
 import org.apache.wink.json4j.JSONArray;
 import org.apache.wink.json4j.JSONException;
 import org.apache.wink.json4j.JSONObject;
+import org.apache.wink.json4j.formatter.FormatOptions;
+import org.apache.wink.json4j.formatter.FormatOptionsBuilderImpl;
 import org.apache.wink.json4j.tests.utils.CauseCauseMatcher;
 import org.apache.wink.json4j.tests.utils.VerifyUtils;
 import org.junit.Before;
@@ -206,7 +208,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test parsing a value which ia a number bigger than <code>Long.MAX_VALUE</code>
+     * Test parsing a value which ia a number bigger than <tt>Long.MAX_VALUE</tt>
      */
     @Test
     public void test_parseNumberGreaterThanMaxLong_throwsException() throws JSONException {
@@ -216,7 +218,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test parsing a value which ia a number smaller than <code>Long.MIN_VALUE</code>
+     * Test parsing a value which ia a number smaller than <tt>Long.MIN_VALUE</tt>
      */
     @Test
     public void test_parseNumberLessThanMinLong_throwsException() throws JSONException {
@@ -250,7 +252,6 @@ public class JSONObjectTest {
     /**
      * Test toString(). Because JSONObject is non-ordered, we could have
      * two possible outcomes for a 2 attribute json object.
-     * TODO: This needs to move to an output formatter
      */
     @Test
     public void test_toStringVerboseWithDepthTo3Spaces() throws Exception {
@@ -279,6 +280,20 @@ public class JSONObjectTest {
         assertTrue(jObject.has("bool"));
         assertTrue(jObject.has("null"));
         assertFalse(jObject.has("noKey"));
+    }
+
+    @Test
+    public void test_putNullKey_throwsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("key must not be null");
+        new JSONObject().put(null, 311);
+    }
+
+    @Test
+    public void test_putKeyIsNotAString_throwsException() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("key must be a String");
+        new JSONObject().put(Integer.valueOf(311), 311);
     }
 
     @Test
@@ -444,7 +459,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getLong</code> with Long.MAX_VALUE
+     * Test <tt>getLong</tt> with Long.MAX_VALUE
      */
     @Test
     public void test_getMaxLongPositive() throws JSONException {
@@ -452,7 +467,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getLong</code> with Long.MIN_VALUE
+     * Test <tt>getLong</tt> with Long.MIN_VALUE
      */
     @Test
     public void test_getMaxLongNegative() throws JSONException {
@@ -461,7 +476,7 @@ public class JSONObjectTest {
 
 
     /**
-     * Test <code>getInt</code> with <code>Integer.MAX_VALUE</code>
+     * Test <tt>getInt</tt> with <tt>Integer.MAX_VALUE</tt>
      */
     @Test
     public void test_getMaxIntegerPositive() throws JSONException {
@@ -469,7 +484,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getInt</code> with <code>Integer.MIN_VALUE</code>
+     * Test <tt>getInt</tt> with <tt>Integer.MIN_VALUE</tt>
      */
     @Test
     public void test_getMaxIntegerNegative() throws JSONException {
@@ -477,7 +492,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with <code>Double.MAX_VALUE</code>
+     * Test <tt>getDouble</tt> with <tt>Double.MAX_VALUE</tt>
      */
     @Test
     public void test_getMaxDoublePositive() throws JSONException {
@@ -485,7 +500,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with <code>Double.MIN_VALUE</code>
+     * Test <tt>getDouble</tt> with <tt>Double.MIN_VALUE</tt>
      */
     @Test
     public void test_getMaxDoubleNegative() throws JSONException {
@@ -493,7 +508,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal
+     * Test <tt>getDouble</tt> with double decimal
      */
     @Test
     public void test_getPositiveDoubleWithDecimal() throws JSONException {
@@ -501,7 +516,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal
+     * Test <tt>getDouble</tt> with negative double decimal
      */
     @Test
     public void test_getNegativeDoubleWithDecimal() throws JSONException {
@@ -509,7 +524,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal with an exponent (eg. e-3)
+     * Test <tt>getDouble</tt> with double decimal with an exponent (eg. e-3)
      */
     @Test
     public void test_getPositiveDoubleWithExponential() throws JSONException {
@@ -518,7 +533,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal with an exponent (eg. e-3)
+     * Test <tt>getDouble</tt> with negative double decimal with an exponent (eg. e-3)
      */
     @Test
     public void test_getNegativeDoubleWithExponential() throws JSONException {
@@ -527,7 +542,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal with an exponent (eg. e+3)
+     * Test <tt>getDouble</tt> with double decimal with an exponent (eg. e+3)
      */
     @Test
     public void test_getPositiveDoubleWithPlusExponential() throws JSONException {
@@ -536,7 +551,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal with an exponent (eg. e+3)
+     * Test <tt>getDouble</tt> with negative double decimal with an exponent (eg. e+3)
      */
     @Test
     public void test_getNegativeDoubleWithPlusExponential() throws JSONException {
@@ -636,7 +651,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal with an exponent (eg. e-3)
+     * Test <tt>getDouble</tt> with double decimal with an exponent (eg. e-3)
      */
     @Test
     public void test_optPositiveDoubleWithExponential() throws JSONException {
@@ -645,7 +660,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal with an exponent (eg. e-3)
+     * Test <tt>getDouble</tt> with negative double decimal with an exponent (eg. e-3)
      */
     @Test
     public void test_optNegativeDoubleWithExponential() throws JSONException {
@@ -654,7 +669,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with double decimal with an exponent (eg. e+3)
+     * Test <tt>getDouble</tt> with double decimal with an exponent (eg. e+3)
      */
     @Test
     public void test_optPositiveDoubleWithPlusExponential() throws JSONException {
@@ -663,7 +678,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> with negative double decimal with an exponent (eg. e+3)
+     * Test <tt>getDouble</tt> with negative double decimal with an exponent (eg. e+3)
      */
     @Test
     public void test_optNegativeDoubleWithPlusExponential() throws JSONException {
@@ -812,7 +827,7 @@ public class JSONObjectTest {
     /* *********************************************************************** */
 
     /**
-     * Test <code>getLong</code> function failure due to type mismatch
+     * Test <tt>getLong</tt> function failure due to type mismatch
      */
     @Test
     public void test_getLong_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -822,7 +837,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> function failure due to type mismatch
+     * Test <tt>getDouble</tt> function failure due to type mismatch
      */
     @Test
     public void test_getDouble_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -832,7 +847,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getInt</code> function failure due to type mismatch
+     * Test <tt>getInt</tt> function failure due to type mismatch
      */
     @Test
     public void test_getInt_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -842,7 +857,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getShort</code> function failure due to type mismatch
+     * Test <tt>getShort</tt> function failure due to type mismatch
      */
     @Test
     public void test_getShort_typeMisMatchString_throwsJSONException() throws JSONException {
@@ -852,7 +867,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getShort</code> function failure due to type mismatch
+     * Test <tt>getShort</tt> function failure due to type mismatch
      */
     @Test
     public void test_getString_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -862,7 +877,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getString</code> function returns string representation of number
+     * Test <tt>getString</tt> function returns string representation of number
      */
     @Test
     public void test_getString_returnsIntegerToString() throws JSONException {
@@ -870,7 +885,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getBoolean</code> function failure due to type mismatch
+     * Test <tt>getBoolean</tt> function failure due to type mismatch
      */
     @Test
     public void test_getBoolean_typeMisMatchNumber_throwsJSONException() throws JSONException {
@@ -880,7 +895,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getLong</code> function failure due to value null
+     * Test <tt>getLong</tt> function failure due to value null
      */
     @Test
     public void test_getLong_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -890,7 +905,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getInt</code> function failure due to value null
+     * Test <tt>getInt</tt> function failure due to value null
      */
     @Test
     public void test_getInt_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -900,7 +915,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getDouble</code> function failure due to value null
+     * Test <tt>getDouble</tt> function failure due to value null
      */
     @Test
     public void test_getDouble_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -910,7 +925,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getShort</code> function failure due to value null
+     * Test <tt>getShort</tt> function failure due to value null
      */
     @Test
     public void test_getShort_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -920,7 +935,7 @@ public class JSONObjectTest {
     }
 
     /**
-     * Test <code>getBoolean</code> function failure due to value null
+     * Test <tt>getBoolean</tt> function failure due to value null
      */
     @Test
     public void test_getBoolean_typeMisMatchNull_throwsJSONException() throws JSONException {
@@ -993,13 +1008,14 @@ public class JSONObjectTest {
         assertEquals("val3", testObj.opt("key3"));
     }
 
-    /***********************************************************/
-    /* The following tests checks UTF-8 encoded DBCS characters*/
-    /***********************************************************/
+    /* ******************************************************** */
+    /* The following tests checks UTF-8 encoded DBCS characters */
+    /* ******************************************************** */
 
     /**
      * Verify a standard UTF-8 file with high character codes (Korean), can be read via a reader and parsed.
      */
+    @SuppressWarnings("EmptyFinallyBlock")
     @Test
     public void test_utf8_korean() throws Exception {
         final String expectedKoreanStr = "\uc548\ub155 \uc138\uc0c1\uc544";
@@ -1016,8 +1032,9 @@ public class JSONObjectTest {
      * serialize correctly in escaped unicode format (which is valid JSON and easier
      * to debug)
      * <p>
-     * TODO: Address this when the toggle for excapted vs unescaped is allowed during outputting
+     * TODO: Address this when the toggle for escaped vs unescaped is allowed during outputting
      */
+    @SuppressWarnings("EmptyFinallyBlock")
     @Test
     public void test_utf8_lowerchar_toStringEscapesCodes() throws Exception {
         try (Reader reader = new InputStreamReader(this.getClass().getClassLoader().getResourceAsStream("utf8_lowerchar.json"), "UTF-8")) {
@@ -1029,6 +1046,33 @@ public class JSONObjectTest {
         }
     }
 
+    @Test
+    public void test_toString_doesNotEscapeForwardSlashes_whenOptionDisabled() throws Exception {
+        final String jsonStr = "{\"special_string\":\"1 > ../log/file-1234.log 2>&1&\"}";
+        assertEquals(jsonStr, new JSONObject(jsonStr).toString(new FormatOptionsBuilderImpl().setEscapeForwardSlashes(false).build()));
+    }
+
+    @Test
+    public void test_toString_putsEmptyArraysBracketsOnSameLine_whenVerboseAndOptionEnabled() throws Exception {
+        final String jsonStr = "{\n\t\"empty_array\": []\n}";
+        assertEquals(jsonStr, new JSONObject(jsonStr).toString(
+                new FormatOptionsBuilderImpl()
+                        .setFormat(FormatOptions.Format.Verbose)
+                        .setNewlineString("\n")
+                        .setEmptyArrayOnSameLine(true)
+                        .build()));
+    }
+
+    @Test
+    public void test_toString_putsEmptyObjectBracesOnSameLine_whenVerboseAndOptionEnabled() throws Exception {
+        final String jsonStr = "{\n\t\"empty_object\": {}\n}";
+        assertEquals(jsonStr, new JSONObject(jsonStr).toString(
+                new FormatOptionsBuilderImpl()
+                        .setFormat(FormatOptions.Format.Verbose)
+                        .setNewlineString("\n")
+                        .setEmptyArrayOnSameLine(true)
+                        .build()));
+    }
 
     /* ************************************************************************************* */
     /* These tests check for specific 'behaviors' so that the parser is compatible to others */

--- a/src/test/java/org/apache/wink/json4j/tests/JSONParserTests.java
+++ b/src/test/java/org/apache/wink/json4j/tests/JSONParserTests.java
@@ -31,6 +31,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -114,39 +117,5 @@ public class JSONParserTests {
         assertEquals(Boolean.TRUE, jArray.get(1));
         assertEquals(311, jArray.get(2));
         assertNull(jArray.get(3));
-    }
-
-    @Ignore("Performance Tests Ignored - parsing Highly nested JSON")
-    @Test
-    public void testHighlyNestedJSON_genericParse() throws Exception {
-        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
-            PerformanceUtils.executeAndTimeInputStreamProcessing(
-                    StringUtils.stringFromInputStream(is),
-                    "Parse highly nested JSON",
-                    inputStream -> {
-                        try {
-                            JSON.parse(inputStream);
-                        } catch (Exception e) {
-                            assertFalse("Test Failed: " + e.getMessage(), true);
-                        }
-                    });
-        }
-    }
-
-    @Ignore("Performance Tests Ignored - parsing Highly nested JSON")
-    @Test
-    public void testHighlyNestedJSON_JSONObjectParse() throws Exception {
-        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
-            PerformanceUtils.executeAndTimeInputStreamProcessing(
-                    StringUtils.stringFromInputStream(is),
-                    "Parse highly nested JSON",
-                    inputStream -> {
-                        try {
-                            new JSONObject(inputStream);
-                        } catch (Exception e) {
-                            assertFalse("Test Failed: " + e.getMessage(), true);
-                        }
-                    });
-        }
     }
 }

--- a/src/test/java/org/apache/wink/json4j/tests/JSONParserTests.java
+++ b/src/test/java/org/apache/wink/json4j/tests/JSONParserTests.java
@@ -19,20 +19,18 @@
 
 package org.apache.wink.json4j.tests;
 
-/**
- * Basic junit imports.
- */
-
 import org.apache.wink.json4j.JSON;
 import org.apache.wink.json4j.JSONArray;
 import org.apache.wink.json4j.JSONArtifact;
 import org.apache.wink.json4j.JSONObject;
+import org.apache.wink.json4j.tests.utils.PerformanceUtils;
+import org.apache.wink.json4j.tests.utils.StringUtils;
 import org.apache.wink.json4j.tests.utils.VerifyUtils;
 import org.apache.wink.json4j.utils.XML;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.InputStream;
-import java.io.StringWriter;
 
 import static org.junit.Assert.*;
 
@@ -105,16 +103,50 @@ public class JSONParserTests {
      */
     @Test
     public void testJSONGenericArrayParse_startingWhitespace() throws Exception {
-            final String json = "\t\t\t    \b\n\f\r   \t\t  [ \"foo\", true, 311, null ]";
-            final JSONArtifact jsonA = JSON.parse(json);
-            assertNotNull(jsonA);
-            assertTrue(jsonA instanceof JSONArray);
+        final String json = "\t\t\t    \b\n\f\r   \t\t  [ \"foo\", true, 311, null ]";
+        final JSONArtifact jsonA = JSON.parse(json);
+        assertNotNull(jsonA);
+        assertTrue(jsonA instanceof JSONArray);
 
-            final JSONArray jArray = (JSONArray) jsonA;
-            assertEquals(4, jArray.length());
-            assertEquals("foo", jArray.get(0));
-            assertEquals(Boolean.TRUE, jArray.get(1));
-            assertEquals(311, jArray.get(2));
-            assertNull(jArray.get(3));
+        final JSONArray jArray = (JSONArray) jsonA;
+        assertEquals(4, jArray.length());
+        assertEquals("foo", jArray.get(0));
+        assertEquals(Boolean.TRUE, jArray.get(1));
+        assertEquals(311, jArray.get(2));
+        assertNull(jArray.get(3));
+    }
+
+    @Ignore("Performance Tests Ignored - parsing Highly nested JSON")
+    @Test
+    public void testHighlyNestedJSON_genericParse() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "Parse highly nested JSON",
+                    inputStream -> {
+                        try {
+                            JSON.parse(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
+        }
+    }
+
+    @Ignore("Performance Tests Ignored - parsing Highly nested JSON")
+    @Test
+    public void testHighlyNestedJSON_JSONObjectParse() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "Parse highly nested JSON",
+                    inputStream -> {
+                        try {
+                            new JSONObject(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
+        }
     }
 }

--- a/src/test/java/org/apache/wink/json4j/tests/PerformanceTests.java
+++ b/src/test/java/org/apache/wink/json4j/tests/PerformanceTests.java
@@ -1,0 +1,179 @@
+package org.apache.wink.json4j.tests;
+
+import org.apache.wink.json4j.JSON;
+import org.apache.wink.json4j.JSONObject;
+import org.apache.wink.json4j.tests.utils.PerformanceUtils;
+import org.apache.wink.json4j.tests.utils.StringUtils;
+import org.apache.wink.json4j.utils.XML;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static org.junit.Assert.assertFalse;
+
+public class PerformanceTests {
+
+    private static HashMap<String, Method> mapTests;
+
+    /**
+     * Load up all the tests and make them executable in the main class.
+     * This would be really helpful to make more generic and pull annotations
+     * that indicate Performance tests, and then be a be able to execute all or
+     * some of the perf tests across the whole test suite, this way perf tests
+     * can be written in the test of the class itself.
+     */
+    static {
+        mapTests = new HashMap<>();
+            Arrays.asList(PerformanceTests.class.getMethods())
+            .stream().forEach(method-> {
+                if (method.getName().startsWith("test_")) {
+                    final String key = method.getName().replace("test_","");
+                    mapTests.put(key, method);
+                }
+            });
+    }
+
+    public PerformanceTests() {
+    }
+
+    @Ignore("Performance Tests Ignored - parsing Highly nested JSON")
+    @Test
+    public void test_parseNestedJsonGenericParser() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "Parse highly nested JSON",
+                    inputStream -> {
+                        try {
+                            JSON.parse(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
+        }
+    }
+
+    @Ignore("Performance Tests Ignored - parsing Highly nested JSON")
+    @Test
+    public void test_parseNestedJsonTypedParser() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "Parse highly nested JSON",
+                    inputStream -> {
+                        try {
+                            new JSONObject(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
+        }
+    }
+
+    @Ignore("Performance Tests Ignored - writing Highly nested JSON verbose")
+    @Test
+    public void test_toStringVerboseNestedObject() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
+            JSONObject obj = new JSONObject(is);
+            PerformanceUtils.executeAndTimeJSONObjectProcessing(
+                    obj,
+                    "writing highly nested JSON (verbose)",
+                    jsonObj -> jsonObj.toString(true));
+        }
+    }
+
+    @Ignore("Performance Tests Ignored - writing Highly nested JSON compact")
+    @Test
+    public void test_toStringCompactNestedObject() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples-highly-nested.json")) {
+            JSONObject obj = new JSONObject(is);
+            PerformanceUtils.executeAndTimeJSONObjectProcessing(
+                    obj,
+                    "writing highly nested JSON (compact)",
+                    jsonObj -> jsonObj.toString(false));
+        }
+    }
+
+    @Ignore("Performance Tests Ignored - simple.xml to JSON")
+    @Test
+    public void test_parseXmlSimple() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("simple.xml")) {
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "Parse simple.xml into JSON Object",
+                    inputStream -> {
+                        try {
+                            XML.toJson(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
+        }
+    }
+
+    @Ignore("Performance Tests Ignored - complex.xml to JSON")
+    @Test
+    public void test_parseXmlComplex() throws Exception {
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("complex.xml")) {
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "Parse complex.xml into JSON Object",
+                    1000,
+                    inputStream -> {
+                        try {
+                            XML.toJson(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
+        }
+    }
+
+    public static void main(String[] args) {
+
+        try {
+            if (null != args) {
+                if ("all".equals(args[0])) {
+                    List<String> allTests = new ArrayList<>(mapTests.keySet());
+                    allTests.sort(Comparator.naturalOrder());
+                    doTests(allTests);
+                } else {
+                    doTests(Arrays.asList(args));
+                }
+            } else {
+                usage();
+            }
+        } catch (NoSuchMethodException e) {
+            System.err.println("Failed to execute tests. Cause: " + e.getMessage());
+            e.printStackTrace(System.err);
+            usage();
+        }
+    }
+
+    private static void usage() {
+        System.err.println();
+        System.err.println(String.format("%s <test1> [<test2>] ...", PerformanceTests.class.getName()));
+        System.err.println("\tAvailable Tests: ");
+        System.err.println("\t\tall");
+        mapTests.keySet().stream().sorted().forEach(testName -> System.err.println("\t\t" + testName));
+    }
+
+    private static void doTests(List<String> testsToRun) throws NoSuchMethodException {
+
+        final PerformanceTests tests = new PerformanceTests();
+        testsToRun.forEach(testName -> executeTest(tests, mapTests.get(testName)));
+    }
+
+    private static void executeTest(final PerformanceTests tests, final Method method) {
+        try {
+            System.out.println("Executing: " + method.getName());
+            method.invoke(tests);
+        } catch (Exception e) {
+            System.err.println("Failed: " + e.getMessage());
+            e.printStackTrace(System.err);
+        }
+    }
+}

--- a/src/test/java/org/apache/wink/json4j/tests/XMLTests.java
+++ b/src/test/java/org/apache/wink/json4j/tests/XMLTests.java
@@ -25,9 +25,7 @@ package org.apache.wink.json4j.tests;
 
 import org.apache.wink.json4j.JSONArray;
 import org.apache.wink.json4j.JSONObject;
-import org.apache.wink.json4j.tests.utils.ComplexXMLConstants;
-import org.apache.wink.json4j.tests.utils.LongTextXMLConstants;
-import org.apache.wink.json4j.tests.utils.SimpleXMLConstants;
+import org.apache.wink.json4j.tests.utils.*;
 import org.apache.wink.json4j.utils.XML;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -35,11 +33,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xml.sax.SAXException;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Tests for all the basic XML Transform functions.
@@ -377,7 +375,16 @@ public class XMLTests {
     @Test
     public void testSimpleXMLDocument_AsInputStreamToStringCompactTiming() throws Exception {
         try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("simple.xml")) {
-            executeAndTimeXmlToJSON(stringFromInputStream(is), "simple.xml");
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "simple.xml",
+                    inputStream -> {
+                        try {
+                            XML.toJson(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
         }
     }
 
@@ -385,37 +392,17 @@ public class XMLTests {
     @Test
     public void testComplexXMLDocument_AsInputStreamToStringCompactTiming() throws Exception {
         try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("complex.xml")) {
-            executeAndTimeXmlToJSON(stringFromInputStream(is), "complex.xml");
+            PerformanceUtils.executeAndTimeInputStreamProcessing(
+                    StringUtils.stringFromInputStream(is),
+                    "complex.xml",
+                    inputStream -> {
+                        try {
+                            XML.toJson(inputStream);
+                        } catch (Exception e) {
+                            assertFalse("Test Failed: " + e.getMessage(), true);
+                        }
+                    });
         }
     }
 
-    private void executeAndTimeXmlToJSON(String strXML, String description) throws Exception {
-        long endTime = 0;
-        long startTime = 0;
-
-        startTime = System.currentTimeMillis();
-        for (int i = 0; i < 10000; i++) {
-
-            try (InputStream strIS = new ByteArrayInputStream(strXML.getBytes(StandardCharsets.UTF_8.name()))) {
-                XML.toJson(strIS);
-            } finally {
-                    /* */
-            }
-        }
-        endTime = System.currentTimeMillis();
-        System.out.println(description + " timing.  Total time for 10000 transforms: [" + (endTime - startTime) + "ms].  Time per execution: [" + ((endTime - startTime) / 10000) + "ms]");
-    }
-
-    private String stringFromInputStream(InputStream is) throws Exception {
-        try (ByteArrayOutputStream result = new ByteArrayOutputStream()) {
-            byte[] buffer = new byte[2048];
-            int length;
-            while ((length = is.read(buffer)) != -1) {
-                result.write(buffer, 0, length);
-            }
-            return result.toString(StandardCharsets.UTF_8.name());
-        } finally {
-/* */
-        }
-    }
 }

--- a/src/test/java/org/apache/wink/json4j/tests/XMLTests.java
+++ b/src/test/java/org/apache/wink/json4j/tests/XMLTests.java
@@ -363,46 +363,4 @@ public class XMLTests {
         }
         assertTrue(ex == null);
     }
-
-    /* ********************************* */
-    /* Performance tests.                */
-    /* ********************************* */
-
-    /**
-     * Test a complex transform of an XML file to a JSON string with compact emit.
-     */
-    @Ignore("Performance Tests Ignored - simple.xml to JSON")
-    @Test
-    public void testSimpleXMLDocument_AsInputStreamToStringCompactTiming() throws Exception {
-        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("simple.xml")) {
-            PerformanceUtils.executeAndTimeInputStreamProcessing(
-                    StringUtils.stringFromInputStream(is),
-                    "simple.xml",
-                    inputStream -> {
-                        try {
-                            XML.toJson(inputStream);
-                        } catch (Exception e) {
-                            assertFalse("Test Failed: " + e.getMessage(), true);
-                        }
-                    });
-        }
-    }
-
-    @Ignore("Performance Tests Ignored - complex.xml to JSON")
-    @Test
-    public void testComplexXMLDocument_AsInputStreamToStringCompactTiming() throws Exception {
-        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream("complex.xml")) {
-            PerformanceUtils.executeAndTimeInputStreamProcessing(
-                    StringUtils.stringFromInputStream(is),
-                    "complex.xml",
-                    inputStream -> {
-                        try {
-                            XML.toJson(inputStream);
-                        } catch (Exception e) {
-                            assertFalse("Test Failed: " + e.getMessage(), true);
-                        }
-                    });
-        }
-    }
-
 }

--- a/src/test/java/org/apache/wink/json4j/tests/utils/PerformanceUtils.java
+++ b/src/test/java/org/apache/wink/json4j/tests/utils/PerformanceUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.tests.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+public class PerformanceUtils {
+
+    private static final int DEFAULT_NUM_LOOPS = 10000;
+
+    private PerformanceUtils() {
+    }
+
+    @SuppressWarnings("EmptyFinallyBlock")
+    public static void executeAndTimeInputStreamProcessing(String str, String description, Consumer<InputStream> c) throws Exception {
+        executeAndTimeInputStreamProcessing(str, description, DEFAULT_NUM_LOOPS, c);
+    }
+
+    public static void executeAndTimeInputStreamProcessing(String str, String description, int numLoops, Consumer<InputStream> c) throws Exception {
+        int timesToExecute = (numLoops > 0) ? numLoops : DEFAULT_NUM_LOOPS;
+
+        long endTime;
+        final long startTime = System.currentTimeMillis();
+        for (int i = 0; i < timesToExecute; i++) {
+
+            try (InputStream is = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8.name()))) {
+                c.accept(is);
+            } finally {
+            }
+        }
+        endTime = System.currentTimeMillis();
+        final double totalTime = endTime - startTime;
+        System.out.println(
+                String.format("%s timing.  Total time for 10000 executions: [%.0fms].  Time per execution: [%.4fms]",
+                        description,
+                        totalTime,
+                        totalTime / timesToExecute));
+    }
+}

--- a/src/test/java/org/apache/wink/json4j/tests/utils/StringUtils.java
+++ b/src/test/java/org/apache/wink/json4j/tests/utils/StringUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wink.json4j.tests.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class StringUtils {
+
+    private StringUtils() {
+    }
+
+    @SuppressWarnings("EmptyFinallyBlock")
+    public static String stringFromInputStream(InputStream is) throws Exception {
+        try (ByteArrayOutputStream result = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[2048];
+            int length;
+            while ((length = is.read(buffer)) != -1) {
+                result.write(buffer, 0, length);
+            }
+            return result.toString(StandardCharsets.UTF_8.name());
+        } finally {
+        }
+    }
+}

--- a/src/test/java/org/apache/wink/json4j/tests/utils/VerifyUtils.java
+++ b/src/test/java/org/apache/wink/json4j/tests/utils/VerifyUtils.java
@@ -46,7 +46,7 @@ public class VerifyUtils {
     }
 
     /**
-     * Verifies the rules described in the Javadoc for <code>XML</code>
+     * Verifies the rules described in the Javadoc for <tt>XML</tt>
      * @param obj The object to verify
      * @throws JSONException
      * @see org.apache.wink.json4j.utils.XML

--- a/src/test/resources/examples-highly-nested.json
+++ b/src/test/resources/examples-highly-nested.json
@@ -1,0 +1,154 @@
+{
+  "items":
+  {
+    "item":
+    [
+      {
+        "id": "0001",
+        "type": "donut",
+        "name": "Cake",
+        "ppu": 0.55,
+        "batters":
+        {
+          "batter":
+          [
+            { "id": "1001", "type": "Regular" },
+            { "id": "1002", "type": "Chocolate" },
+            { "id": "1003", "type": "Blueberry" },
+            { "id": "1004", "type": "Devil's Food" }
+          ]
+        },
+        "topping":
+        [
+          { "id": "5001", "type": "None" },
+          { "id": "5002", "type": "Glazed" },
+          { "id": "5005", "type": "Sugar" },
+          { "id": "5007", "type": "Powdered Sugar" },
+          { "id": "5006", "type": "Chocolate with Sprinkles" },
+          { "id": "5003", "type": "Chocolate" },
+          { "id": "5004", "type": "Maple" }
+        ]
+      },
+      {
+        "id": "0002",
+        "type": "donut",
+        "name": "Raised",
+        "ppu": 0.55,
+        "batters":
+        {
+          "batter":
+          [
+            { "id": "1001", "type": "Regular" }
+          ]
+        },
+        "topping":
+        [
+          { "id": "5001", "type": "None" },
+          { "id": "5002", "type": "Glazed" },
+          { "id": "5005", "type": "Sugar" },
+          { "id": "5003", "type": "Chocolate" },
+          { "id": "5004", "type": "Maple" }
+        ]
+      },
+
+      {
+        "id": "0003",
+        "type": "donut",
+        "name": "Old Fashioned",
+        "ppu": 0.55,
+        "batters":
+        {
+          "batter":
+          [
+            { "id": "1001", "type": "Regular" },
+            { "id": "1002", "type": "Chocolate" }
+          ]
+        },
+        "topping":
+        [
+          { "id": "5001", "type": "None" },
+          { "id": "5002", "type": "Glazed" },
+          { "id": "5003", "type": "Chocolate" },
+          { "id": "5004", "type": "Maple" }
+        ]
+      },
+      {
+        "id": "0004",
+        "type": "bar",
+        "name": "Bar",
+        "ppu": 0.75,
+        "batters":
+        {
+          "batter":
+          [
+            { "id": "1001", "type": "Regular" }
+          ]
+        },
+        "topping":
+        [
+          { "id": "5003", "type": "Chocolate" },
+          { "id": "5004", "type": "Maple" }
+        ],
+        "fillings":
+        {
+          "filling":
+          [
+            { "id": "7001", "name": "None", "addcost": 0 },
+            { "id": "7002", "name": "Custard", "addcost": 0.25 },
+            { "id": "7003", "name": "Whipped Cream", "addcost": 0.25 }
+          ]
+        }
+      },
+
+      {
+        "id": "0005",
+        "type": "twist",
+        "name": "Twist",
+        "ppu": 0.65,
+        "batters":
+        {
+          "batter":
+          [
+            { "id": "1001", "type": "Regular" }
+          ]
+        },
+        "topping":
+        [
+          { "id": "5002", "type": "Glazed" },
+          { "id": "5005", "type": "Sugar" }
+        ]
+      },
+
+      {
+        "id": "0006",
+        "type": "filled",
+        "name": "Filled",
+        "ppu": 0.75,
+        "batters":
+        {
+          "batter":
+          [
+            { "id": "1001", "type": "Regular" }
+          ]
+        },
+        "topping":
+        [
+          { "id": "5002", "type": "Glazed" },
+          { "id": "5007", "type": "Powdered Sugar" },
+          { "id": "5003", "type": "Chocolate" },
+          { "id": "5004", "type": "Maple" }
+        ],
+        "fillings":
+        {
+          "filling":
+          [
+            { "id": "7002", "name": "Custard", "addcost": 0 },
+            { "id": "7003", "name": "Whipped Cream", "addcost": 0 },
+            { "id": "7004", "name": "Strawberry Jelly", "addcost": 0 },
+            { "id": "7005", "name": "Rasberry Jelly", "addcost": 0 }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/versioning.gradle
+++ b/versioning.gradle
@@ -17,13 +17,14 @@ ext {
       print '##teamcity[buildNumber \'' + major + '.' + minor + '.' + patch + '\']'
     } else {
       ext.env = System.getenv()
-      ext.buildNumber = env.BUILD_NUMBER?.toInteger()
-      if (env.hasProperty('BUILD_NUMBER')) {
-        patch = env.BUILD_NUMBER?.toInteger()
-        print '##jenkins[buildNumber \'' + major + '.' + minor + '.' + patch + '\']'
+      def buildNumber = env.BUILD_NUMBER?.toInteger()
+      if (buildNumber) {
+        patch = buildNumber
+        println '##jenkins[buildNumber \'' + major + '.' + minor + '.' + patch + '\']'
       }
     }
 
     return major + '.' + minor + '.' + patch
   }
+
 }


### PR DESCRIPTION
Writing JSON objects to strings now accept a FormatOptions parameter
  which allows more control beyond just verbose and indent, on how
  the json is output.

Adds support for same line outputting for empty objects and arrays
Adds support for optionally escaping / characters

Also address a bunch of old-style java issues, starting to add more typed
 classes
Cleans up some SonarLint recommended fixes